### PR TITLE
System specification table of contents is now navigatable.

### DIFF
--- a/docs/Pflichtenheft.tex
+++ b/docs/Pflichtenheft.tex
@@ -4,6 +4,13 @@
 \usepackage[T1]{fontenc}
 \usepackage[german]{babel}
 \usepackage[pangram]{blindtext}
+\usepackage{hyperref}
+
+\hypersetup{
+  colorlinks=false,
+  linktoc=all,
+  hidelinks,
+}
 
 \title{Pflichtenheft}
 \subtitle{Implementierung eines OPC UA Systemadapters für den Industrial Data Space}


### PR DESCRIPTION
LaTex warning is due to multiple use of '\Blindtext[1]'-tag. Should not be a problem later on.