### PR TITLE
[doc] Sorted the FAs.

### DIFF
--- a/docs/Glossary.tex
+++ b/docs/Glossary.tex
@@ -100,7 +100,7 @@
 {
   name=Simulations-Szenario,
   plural=Simulations-Szenarien,
-  description={Automatisierte Veränderung von Eigenschaften der Fertigungssimulation}
+  description={Fester, zeitlicher, automatisierter Ablauf zur Veränderung von Eigenschaften der \gls{Fertigungssimulation}, um komplexere Szenarien darzustellen.}
 }
 
 \newglossaryentry{Systemadapter}

--- a/docs/Pflichtenheft.tex
+++ b/docs/Pflichtenheft.tex
@@ -9,6 +9,7 @@
 \usepackage{graphicx}
 \usepackage{enumitem}
 \usepackage{float}
+\usepackage{color}
 
 \hypersetup{
   colorlinks=false,
@@ -199,124 +200,122 @@ mindestens 2GHz getaktet sein.
 
 \pagebreak
 \section{Funktionale Anforderungen}
+Im Nachfolgenden sind die Nummern optionaler Funktionalitäten, die sich aus den Kann-Kriterien ergeben, \textcolor{blue}{blau} markiert.
+
 \subsection{Fertigungssimulation}
 \subsubsection{Funktionalität}
-\begin{enumerate}
-  \item[FA10] Die \gls{Produktionsanlage} wird innnerhalb der \glspl{OPC UA Server} repräsentiert.
-  \item[FA10] Der Betrieb der \gls{Produktionsanlage} wird simuliert und grafisch dargestellt.
-  \item[FA10] Die Zu- und Abflussmengen der oberen (siehe FA110) Flüssigkeitstanks können seperat eingestellt werden.
-  \item[FA20] Die Abflussmenge des unteren (siehe FA110) Flüssigkeitstanks kann eingestellt werden. Die Zuflussmenge ergibt sich aus der Summe der Abflussmengen der oberen Tanks.
-  \item[FA30] Der untere Tank enthält einen motorbetriebenen Mischer, dessen Drehzahl eingestellt werden kann.
-  \item[FA40] Jedem der oberen Tanks ist eine feste Flüssigkeitsfarbe zugeordnet. Die Farbe des unteren Tanks ergibt sich aus dem Mischungsverhältnis der oberen Tanks. Dabei wird
-    angenommen, dass die Flüssigkeiten der oberen Tanks die selbe Deckkraft haben.
-  \item[FA40] Der linke obere Tank wird mit roter, der mittlere mit grüner und der rechte mit blauer Flüssigkeit gefüllt.
-  \item[FA45] Die Zuflusstemperaturen der oberen Tanks können seperat eingestellt werden (Kann-Kriterium).
-  \item[FA50] Es gibt eine .jar Datei, die bei Ausführung die \gls{Fertigungssimulation}, sowie zugehörige \gls{OPC UA Server} startet.
-  \item[FA60] Nach Anforderung durch die \gls{Uberwachungskonsole} wird in bestimmten, in der Anfrage definierten, Zust\"anden ein Alarm an die \glspl{OPC UA Client} der \gls{Uberwachungskonsole} gesendet.
-  \item[FA70] Kommt es in der \gls{Fertigungssimulation} zu einem \"Uberlauf so h\"alt die \gls{Fertigungssimulation} an und es wird der Text "`\"Uberlauf"' angezeigt.
-  \item[FA80] Das System wird aus einem "`\"Uberlauf"' durch den Knopf "`zur\"ucksetzen"' im gezeigten Dialog wieder in den Startzustand versetzt. Anschlie{\ss}end wird die Ausführung fortgesetzt.
-  \item[FA90] Die \glspl{OPC UA Client} der \gls{Uberwachungskonsole} registrieren sich bei den \glslink{OPC UA Server}{OPC UA Servern} der \gls{Fertigungssimulation} und empfangen von
+\begin{enumerate}	
+  \item[FA10] Es gibt eine .jar Datei, die bei Ausführung die \gls{Fertigungssimulation} sowie zugehörige \glspl{OPC UA Server} startet.
+  \item[\textcolor{blue}{FA20}] Es gibt ein \gls{Dockerimage} zur einfachen Verteilung und isolierten Ausführung der \gls{Fertigungssimulation}.  
+  \item[FA30] Die \gls{Fertigungssimulation} wird nach der Model-View-Controller-Architektur entworfen.
+  \item[FA40] Der Betrieb der \gls{Produktionsanlage} wird simuliert und grafisch dargestellt.
+  \item[FA50] Die \gls{Produktionsanlage} wird innerhalb der \glspl{OPC UA Server} repräsentiert.
+  \item[FA60] Die Ports, über welche die einzelnen \gls{OPC UA Server} der \gls{Fertigungssimulation} kommunizieren, können eingestellt werden.
+  \item[FA70] Die \gls{Fertigungssimulation} aktualisiert die \glspl{Sensordatum} ihrer \glspl{OPC UA Server}.    
+  \item[FA80] Die \glspl{OPC UA Client} der \gls{Uberwachungskonsole} registrieren sich bei den \glslink{OPC UA Server}{OPC UA Servern} der \gls{Fertigungssimulation} und empfangen von
     diesen \glspl{Sensordatum}.
-  \item[FA110] Die Füllstände der Tanks werden gemessen.
-  \item[FA130] Die Ports, über welche die einzelnen \gls{OPC UA Server} der \gls{Fertigungssimulation} kommunizieren, können eingestellt werden.
-  \item[FA140] Die \gls{Fertigungssimulation} besitzt vordefinierte \glspl{Simulations-Szenario}, die über das Menü gestartet werden können (Kann-Kriterium).
-  \item[FA150] Ein \gls{Simulations-Szenario} ist ein fester, zeitlicher Ablauf, der komplexere Szenarien in der \gls{Fertigungssimulation} darstellt. Somit kann ohne aktive Nutzerinteraktion eine sich
+  \item[FA90] Nach Anforderung durch die \gls{Uberwachungskonsole} wird in bestimmten, der Anfrage definierten Zust\"anden ein Alarm an die \glspl{OPC UA Client} der \gls{Uberwachungskonsole} gesendet.
+  \item[\textcolor{blue}{FA100}] Fehler und Ausnahmen bei der Ausführung werden geloggt.  
+  \item[\textcolor{blue}{FA110}] Die \gls{Fertigungssimulation} verfügt über einen \gls{Jitter}.
+  \item[\textcolor{blue}{FA120}] Die \gls{Fertigungssimulation} besitzt vordefinierte \glspl{Simulations-Szenario}, die über das Menü gestartet werden können. Somit kann ohne aktive Nutzerinteraktion eine sich
     im aktiven Betrieb befindliche \gls{Produktionsanlage} simuliert werden.
-  \item[FA160] Die \gls{Fertigungssimulation} aktualisiert die Sensorwerte ihrer \glspl{OPC UA Server}.
 \end{enumerate}
 
 \subsubsection{GUI Darstellung}
 \begin{enumerate}
-  \item[FA110] Die \gls{GUI} der \gls{Fertigungssimulation} zeigt drei Tanks, die auf einer Höhe sind, und einen Tank unter den oberen drei.
+  \item[FA130] Die \gls{GUI} der \gls{Fertigungssimulation} zeigt drei Flüssigkeitstanks, die auf einer Höhe sind, und einen weiteren Flüssigkeitstank unter den oberen drei.
     Es führen Leitungen von den drei oberen Tanks zum unteren Tank.
-  \item[FA150] An jeder Leitung befinden sich ein Ventil sowie ein Durchflussmesser in Form eines sich drehenden Elements. Der Öffnungsgrad des Ventils wird prozentual auf dem Ventil angezeigt.
-  \item[FA120] Der Mischer im unteren Flüssigkeitstank wird durch ein sich drehendes GUI Element dargestellt.
+  \item[FA140] An jeder Leitung befinden sich ein Ventil sowie ein Durchflussmesser in Form eines sich drehenden Elements. Der Öffnungsgrad des Ventils wird prozentual auf dem Ventil angezeigt.
+  \item[FA150] Die Zu- und Abflussmengen der oberen (siehe FA110) Flüssigkeitstanks können separat eingestellt werden.
+  \item[FA160] Die Abflussmenge des unteren (siehe FA110) Flüssigkeitstanks kann eingestellt werden. Die Zuflussmenge ergibt sich aus der Summe der Abflussmengen der oberen Tanks.
+  \item[FA170] Jedem der oberen Tanks ist eine feste Flüssigkeitsfarbe zugeordnet. Die Farbe des unteren Tanks ergibt sich aus dem Mischungsverhältnis der oberen Tanks. Dabei wird
+	angenommen, dass die Flüssigkeiten der oberen Tanks die selbe Deckkraft haben.
+  \item[FA180] Der linke obere Tank wird mit roter, der mittlere mit grüner und der rechte mit blauer Flüssigkeit gefüllt.
+  \item[FA190] Die Füllstände der Tanks werden gemessen.
+  \item[FA200] Der Füllstand der Flüssigkeitstanks wird durch das Füllen der Tanks in der Farbe ihrer Flüssigkeit dargestellt.
+  \item[FA210] Der untere Tank enthält einen motorbetriebenen Mischer, dessen Drehzahl eingestellt werden kann.
+  \item[FA220] Der Mischer im unteren Tank wird durch ein sich drehendes \gls{GUI} Element dargestellt.
     Die Umdrehungsgeschwindigkeit repräsentiert die Drehzahl des Mischermotors.
-  \item[FA150] An jedem Tank ist ein Temperatursensor angebracht (sofern implementiert).
-  \item[FA130] Der Füllstand der Flüssigkeitstanks wird durch das Füllen der Tanks in der Farbe ihrer Flüssigkeit dargestellt.
-  \item[FA140] Die einstellbaren Parameter können in einem Unterfenster eingestellt werden. Darin existiert für jeden Tank ein eigener Reiter, der die 
-    tankspezifischen Einstellungen wie zum Beispiel Zu- und Abflussmengen, Zuflusstemperaturen oder Motordrehzahlen (siehe FA10 bis FA30) enthält.
-    Diese Parameter werden durch Schieberegler eingestellt.
-  \item[FA150] Jeder der dargestellten Tanks ist mit einer hellgrauen Box hinterlegt, welche den Zuständigkeitsbereich des jeweiligen \glslink{OPC UA Server}{OPC UA Servers} repräsentiert.
-  \item[FA160] Die \gls{Fertigungssimulation} besitzt einen "`Über"'-Dialog, welcher Lizenzinfos zu verwendeten Bibliotheken,
+  \item[\textcolor{blue}{FA230}] An jedem Tank ist ein Temperatursensor angebracht.
+  \item[\textcolor{blue}{FA240}] Die Zuflusstemperaturen der oberen Tanks können separat eingestellt werden.
+  \item[FA250] Jeder der dargestellten Tanks ist mit einer hellgrauen Box hinterlegt, welche den Zuständigkeitsbereich des jeweiligen \glslink{OPC UA Server}{OPC UA Servers} repräsentiert.
+  \item[FA260] Kommt es in der \gls{Fertigungssimulation} zu einem \"Uberlauf, so h\"alt die \gls{Fertigungssimulation} an und es wird der Text "`\"Uberlauf"' angezeigt.
+  \item[FA270] Das System wird aus einem "`\"Uberlauf"' durch den Knopf "`Zur\"ucksetzen"' im gezeigten Dialog wieder in den Startzustand versetzt. Anschlie{\ss}end wird die Ausführung fortgesetzt.	
+  \item[FA280] Die \gls{Fertigungssimulation} besitzt einen "`Über"'-Dialog, welcher Lizenzinformationen zu verwendeten Bibliotheken
     sowie eine kurze Information zu den Erstellern des Programms, enthält.
-  \item[FA180] Der Einstellungsdialog besitzt Buttons zum Verwerfen ("`Abbrechen"') und Anwenden der Änderungen. Das Anwenden geschieht über einen "`OK"'-Button, welcher zudem den Dialog schließt.
-  \item[FA200] Der Einstellungsdialog besitzt einen Regler, welcher den \gls{Jitter} durch einen Schieberegler konfigurierbar macht.
+  \item[FA290] Der Menüeintrag "`Szenarien"' zeigt eine Liste der \glspl{Simulations-Szenario}, die durch einen Klick gestartet werden können.
+  \item[FA300] Die einstellbaren Parameter können in einem Einstellungsdialog festgelegt werden. Darin existiert für jeden Tank ein eigener Reiter, der die 
+    tankspezifischen Einstellungen, wie zum Beispiel Zu- und Abflussmengen, Zuflusstemperaturen oder Motordrehzahlen enthält.
+    Diese Parameter werden durch Schieberegler eingestellt.
+  \item[\textcolor{blue}{FA310}] Der Einstellungsdialog besitzt einen Regler, welcher den \gls{Jitter} konfigurierbar macht.
     Hierbei entspricht ein \gls{Jitter} von 0 der Deaktivierung der Funktion.
-  \item[FA210] Der Menüeintrag "`Szenarien"' zeigt eine Liste der \glspl{Simulations-Szenario}, die durch einen Klick gestartet werden können.
-\end{enumerate}
-
-\subsubsection{Optionale Funktionalität}
-\label{fertigung-optional}
-\begin{enumerate}
-  \item[FA240] Es gibt ein \gls{Dockerimage} zur einfachen Verteilung und isolierten Ausführung der \gls{Fertigungssimulation}.
-  \item[FA250] Fehler und Ausnahmen bei der Ausführung werden geloggt.
+  \item[\textcolor{blue}{FA320}] Im Einstellungsdialog kann die Sprache der \gls{Fertigungssimulation} bestimmt werden.
+  \item[FA330] Die Standardsprache der \gls{GUI} ist Englisch.
+  \item[FA340] Der Einstellungsdialog besitzt Knöpfe zum Verwerfen ("`Abbrechen"') und Anwenden ("`Speichern"') der Änderungen. Ein Klick auf einer der beiden Knöpfe schließt zudem den Dialog.    
 \end{enumerate}
 
 \subsection{Überwachungskonsole}
 \subsubsection{Funktionalität}
 \begin{enumerate}
-  \item[FA310] Es gibt eine .jar-Datei, die bei Ausführung die \gls{Uberwachungskonsole} startet.
-  \item[FA320] Die \gls{Uberwachungskonsole} enthält vier \glspl{OPC UA Client}, von denen sich jeder mit einem \gls{OPC UA Server} der \gls{Fertigungssimulation} verbindet und mit diesem über \gls{TCP/IP} per \gls{OPC UA} kommuniziert.
-  \item[FA330] Die \glspl{OPC UA Client} erhalten die \gls{IP-Adresse}, die durch die \gls{Uberwachungskonsole} nicht geändert werden kann, des verwendeten Computers.
-  \item[FA350] Beim Start versucht die \gls{Uberwachungskonsole}, eine Verbindung mit den \glslink{OPC UA Server}{OPC UA Servern} herzustellen und sich dort zu registrieren.
-  \item[FA360] Schlägt die Verbindung von [FA350] oder [FA600] fehl oder verliert mindestens ein \gls{OPC UA Client} die Verbindung zu seinem \gls{OPC UA Server}, wird der Benutzer über einen Dialog informiert und das Einstellungsfenster zur Eingabe der \gls{IP-Adresse} und Ports der \glspl{OPC UA Server} öffnet sich.
-  \item[FA370] Alle angezeigten \glspl{Sensordatum} werden mit einer eingestellten, festen Frequenz aktualisiert. Dabei fragen die \glspl{OPC UA Client} die Daten der \glspl{OPC UA Server}
+  \item[FA350] Es gibt eine .jar-Datei, die bei Ausführung die \gls{Uberwachungskonsole} startet.
+  \item[\textcolor{blue}{FA360}] Es gibt ein \gls{Dockerimage} zur einfachen Verteilung und isolierten Ausführung der \gls{Uberwachungskonsole}.
+  \item[FA370] Die \gls{Uberwachungskonsole} wird nach der Model-View-Controller-Architektur entworfen.
+  \item[FA380] Die \gls{Uberwachungskonsole} enthält vier \glspl{OPC UA Client}, von denen sich jeder mit einem \gls{OPC UA Server} der \gls{Fertigungssimulation} verbindet und mit diesem über \gls{TCP/IP} per
+    \gls{OPC  UA} kommuniziert.
+  \item[FA390] Die \glspl{OPC UA Client} erhalten die \glslink{TCP/IP}{IP-Adresse}, die durch die \gls{Uberwachungskonsole} nicht geändert werden kann, des verwendeten Computers.
+  \item[FA400] Die \glspl{OPC UA Client} erhalten beim Start die Ports automatisch durch das Betriebssystem.
+  \item[FA410] Beim Start versucht die \gls{Uberwachungskonsole}, eine Verbindung zwischen den \glspl{OPC UA Client} und den \glslink{OPC UA Server}{OPC UA Servern} herzustellen und sich so bei der
+    \gls{Fertigungssimulation} zu registrieren.
+  \item[FA420] Alle angezeigten \glspl{Sensordatum} werden mit einer festen Frequenz aktualisiert. Dabei fragen die \glspl{OPC UA Client} die Daten der \glspl{OPC UA Server}
     ab und stellen sie anschlie{\ss}end der \gls{Uberwachungskonsole} bereit.
-  \item[FA380] Alarme mit ihrem jeweiligen Auslöser werden bei den \glslink{OPC UA Server}{OPC UA Servern} der \gls{Fertigungssimulation} registriert. Sie werden von den
+  \item[FA430] Alarme mit ihrem jeweiligen Auslöser werden bei den \glslink{OPC UA Server}{OPC UA Servern} der \gls{Fertigungssimulation} registriert. Sie werden von den
     \glslink{OPC UA Client}{OPC UA Clients} der \gls{Uberwachungskonsole} empfangen und an die \gls{Uberwachungskonsole} weitergeleitet.
-  \item[FA390] Alarme werden asynchron zu den \glspl{Sensordatum} empfangen und über einen Dialog direkt angezeigt, sobald sie ausgelöst werden.
+  \item[FA440] Alarme werden asynchron zu den \glspl{Sensordatum} empfangen.
+  \item[\textcolor{blue}{FA450}] Bereits registrierte Alarme können wieder gelöscht werden.    
+  \item[\textcolor{blue}{FA460}] Geloggt werden Fehler und Ausnahmen während der Ausführung der \gls{Uberwachungskonsole} sowie alle eintreffenden Alarme.
 \end{enumerate}
 
 \subsubsection{GUI Darstellung}
 \begin{enumerate}
-  \item[FA400] Die \gls{Uberwachungskonsole} stellt die \glspl{Sensordatum} und Alarme jedes Flüssigkeitsanks in einem eigenen Bereich dar.
-  \item[FA410] Die \gls{Uberwachungskonsole} zeigt die Farbe der Tanks an.
-  \item[FA420] Die \gls{Uberwachungskonsole} zeigt die Zuflussmenge der oberen Tanks auf jeweils einer Skala an.
-  \item[FA430] Die \gls{Uberwachungskonsole} zeigt die Abflussmenge aller Tanks auf jeweils einer Skala an.
-  \item[FA440] Die \gls{Uberwachungskonsole} zeigt den Füllstand aller Tanks auf jeweils einer Skala an.
-  \item[FA450] Die \gls{Uberwachungskonsole} zeigt die Temperatur aller Tanks auf jeweils einer Skala an (sofern implementiert).
-  \item[FA460] Die \gls{Uberwachungskonsole} zeigt die Drehzahl des Mischermotors im unteren Tank auf einer Skala an.
-  \item[FA470] Der zeitliche Verlauf des Füllstandes wird jeweils für alle Tanks angezeigt.
-  \item[FA480] Der zeitliche Verlauf der Temperatur wird jeweils für alle Tanks angezeigt.
-  \item[FA490] Die \gls{Uberwachungskonsole} registriert für jeden Tank jeweils einen Alarm für einen Überlauf.
-  \item[FA500] Die \gls{Uberwachungskonsole} registriert für jeden Tank jeweils einen Alarm für einen Unterlauf.
-  \item[FA510] Ein Alarm wird durch einen Bezeichner und einen Kreis als Zustandssymbol dargestellt.
-  \item[FA520] Ist der Kreis rot, wurde der Alarm ausgelöst.
-  \item[FA530] Ist der Kreis grün, ist der Alarm nicht ausgelöst.
-  \item[FA540] Ein Alarm wird als ausgelöst angezeigt, nachdem die \gls{Uberwachungskonsole} durch die \gls{Fertigungssimulation} darüber benachrichtigt wurde und bis der Alarm in der
+  \item[FA470] Die \gls{Uberwachungskonsole} stellt die \glspl{Sensordatum} und Alarme jedes Flüssigkeitsanks in einem eigenen Bereich dar.
+  \item[FA480] Die \gls{Uberwachungskonsole} zeigt die Farbe der Tanks an.
+  \item[FA490] Die \gls{Uberwachungskonsole} zeigt die Zuflussmenge der oberen Tanks auf jeweils einer Skala an.
+  \item[FA500] Die \gls{Uberwachungskonsole} zeigt die Abflussmenge aller Tanks auf jeweils einer Skala an.
+  \item[FA510] Die \gls{Uberwachungskonsole} zeigt den Füllstand aller Tanks auf jeweils einer Skala an.
+  \item[\textcolor{blue}{FA520}] Die \gls{Uberwachungskonsole} zeigt die Temperatur aller Tanks auf jeweils einer Skala an.
+  \item[FA530] Die \gls{Uberwachungskonsole} zeigt die Drehzahl des Mischermotors im unteren Tank auf einer Skala an.
+  \item[FA540] Der zeitliche Verlauf des Füllstandes wird jeweils für alle Tanks angezeigt.
+  \item[FA550] Der zeitliche Verlauf der Temperatur wird jeweils für alle Tanks angezeigt.
+  \item[FA560] Die \gls{Uberwachungskonsole} registriert für jeden Tank jeweils einen Alarm für einen Überlauf.
+  \item[FA570] Die \gls{Uberwachungskonsole} registriert für jeden Tank jeweils einen Alarm für einen Unterlauf.
+  \item[FA580] Ein Alarm wird durch einen Bezeichner und einen Kreis als Zustandssymbol dargestellt.
+  \item[FA590] Ist der Kreis rot, wurde der Alarm ausgelöst.
+  \item[FA600] Ist der Kreis grün, ist der Alarm nicht ausgelöst.
+  \item[\textcolor{blue}{FA610}] Der Benutzer kann die Schwellenwerte der Alarme direkt an der Anzeige [FA580] ändern.
+  \item[FA620] Der Benutzer wird über einen Dialog und durch einen roten Kreis der Anzeige des entsprechenden Alarms direkt benachrichtigt, sobald sie ausgelöst werden.
+  \item[FA630] Ein Alarm wird als ausgelöst angezeigt, womit dessen Kreis rot ist, nachdem die \gls{Uberwachungskonsole} durch die \gls{Fertigungssimulation} darüber benachrichtigt wurde und bis der Alarm in der
     \gls{Fertigungssimulation} nicht mehr aktiv ist und die \gls{Uberwachungskonsole} mit der nächsten Aktualisierung der \glspl{Sensordatum} über das Ende informiert wurde.
-  \item[FA550] Es gibt eine zweistufige Ampel für den allgemeinen Zustand der \gls{Uberwachungskonsole}.
-  \item[FA560] Ist die Ampel rot, wurde mindestens ein Alarm ausgelöst.
-  \item[FA570] Ist die Ampel grün, wurde kein Alarm ausgelöst.
-  \item[FA590] Der Menüeintrag "`Über'" öffnet ein neues Fenster, in dem der Programmname, die Version, das Programmsymbol und die Lizenz einschließlich der Lizenzen verwendeter Bibliotheken angezeigt werden.
-  \item[FA600] Der Menüeintrag "`Einstellungen"' öffnet ein separates Fenster.
-  \item[FA610] In den Einstellungen werden die \glslink{TCP/IP}{IP-Adresse} der \glslink{OPC UA Client}{OPC UA Clients} und der \gls{OPC UA Server} sowie deren Ports angezeigt.
-\end{enumerate}
-
-\subsubsection{Benutzerinteraktion}
-\begin{enumerate}
-  \item[FA570] In den Einstellungen sind die Ports für die \glspl{OPC UA Client} bzw. die Ports und die IP-Adresse für die \glspl{OPC UA Server} konfigurierbar.
-  \item[FA580] Nach Drücken eines Speichern-Knopfes im Einstellungsfenster werden alle vorhandenen Einstellungen mit denen aus dem Fenster überschrieben.
-  \item[FA590] Nach Drücken eines Abbruch-Knopfes im Einstellungsfenster bleiben die Einstellungen unverändert.
-  \item[FA600] Werden Einstellungen für die \glspl{OPC UA Server} oder \glspl{OPC UA Client} überschrieben, werden die \glspl{OPC UA Client} mit den neuen Einstellungen neu gestartet.
-  \item[FA610] Die Eingaben in den Einstellungen werden direkt nach Eingabe auf richtige Formatierung und Einhaltung des Wertebereichs gepr\"uft.
-  \item[FA620] Der Benutzer wird über eine Fehleingabe und deren Ursache informiert.
-\end{enumerate}
-
-\subsubsection{Optionale Funktionalität}
-\label{konsole-optional}
-\begin{enumerate}
-  \item[FA630] Es gibt ein \gls{Dockerimage} zur einfachen Verteilung und isolierten Ausführung der \gls{Uberwachungskonsole}.
-  \item[FA640] Bereits registrierte Alarme können wieder gelöscht werden.
-  \item[FA650] Das Einstellungsfenster wird um zwei Reiter, "`Verläufe"' und "`Alarme"' erweitert.
-  \item[FA] In den "Allgemeinen Einstellungen" ist es dem Nutzer möglich, die Sprache auszuwählen.
-  \item[FA660] In den "`Allgemeinen Einstellungen"' ist es dem Nutzer möglich, das Zeitintervall für die Aktualisierung der Werte über einen Schieberegler oder eine Textbox einzustellen.
-  \item[FA670] Unter "`Verläufe"' ist es möglich, jede Aufnahme des zeitlichen Verlaufs eines Wertes ein und aus zu schalten.
-  \item[FA680] In "`Alarme"' kann der Nutzer die verfügbaren Alarme ein- und ausschalten und deren Schwellenwerte festlegen.
-  \item[FA] Der Benutzer kann die Schwellenwerte der Alarme direkt an deren Anzeige ändern.
-  \item[FA690] Es gibt eine Loggingkonsole in Form einer mehrzeiligen Textausgabe.
-  \item[FA700] Geloggt werden Fehler und Ausnahmen während der Ausführung der \gls{Uberwachungskonsole} sowie alle eintreffenden Alarme.
+  \item[FA640] Es gibt eine zweistufige Ampel für den allgemeinen Zustand der \gls{Uberwachungskonsole}.
+  \item[FA650] Ist die Ampel rot, wurde mindestens ein Alarm ausgelöst.
+  \item[FA660] Ist die Ampel grün, wurde kein Alarm ausgelöst.
+  \item[\textcolor{blue}{FA670}] Es gibt eine Loggingkonsole in Form einer mehrzeiligen Textausgabe, die die geloggten Ereignisse der \gls{Uberwachungskonsole} ausgibt.
+  \item[FA680] Der Menüeintrag "`Über'" öffnet ein neues Fenster, in dem der Programmname, die Version, das Programmsymbol und die Lizenz einschließlich der Lizenzen verwendeter Bibliotheken angezeigt werden.
+  \item[FA690] Der Menüeintrag "`Einstellungen"' öffnet ein separates Fenster.
+  \item[FA700] In den Einstellungen werden die \glslink{TCP/IP}{IP-Adresse} der \glslink{OPC UA Client}{OPC UA Clients} und der \gls{OPC UA Server} sowie deren Ports angezeigt.
+  \item[FA710] In den Einstellungen sind die Ports und die IP-Adresse der \glspl{OPC UA Server} konfigurierbar.
+  \item[\textcolor{blue}{FA720}] In den Einstellungen sind die Ports der \glspl{OPC UA Client} konfigurierbar.
+  \item[\textcolor{blue}{FA730}] In den Einstellungen ist es dem Nutzer möglich, die Sprache auszuwählen.
+  \item[FA740] Die Standardsprache ist Englisch.
+  \item[\textcolor{blue}{FA750}] Der Nutzer kann das Zeitintervall für die Aktualisierung der Werte über einen Schieberegler oder eine Textbox einstellen.
+  \item[\textcolor{blue}{FA760}] Die Aufnahme des zeitlichen Verlaufs jedes Füllstandes und jeder Temperatur ist ein- und ausschaltbar.
+  \item[\textcolor{blue}{FA770}] Der Nutzer kann die verfügbaren Alarme ein- und ausschalten und deren Schwellenwerte festlegen.
+  \item[FA780] Die Eingaben in den Einstellungen werden direkt nach Eingabe auf richtige Formatierung und Einhaltung des Wertebereichs gepr\"uft.
+  \item[FA790] Der Benutzer wird über eine Fehleingabe und deren Ursache informiert.
+  \item[FA800] Nach Drücken eines Abbruch-Knopfes im Einstellungsfenster bleiben die Einstellungen unverändert.
+  \item[FA810] Nach Drücken eines Speichern-Knopfes im Einstellungsfenster werden alle vorhandenen Einstellungen mit denen aus dem Fenster überschrieben.
+  \item[FA820] Werden Einstellungen für die \glspl{OPC UA Server} oder \glspl{OPC UA Client} überschrieben, werden die \glspl{OPC UA Client} mit den neuen Einstellungen neu gestartet.
+  \item[FA830] Schlägt die Verbindung zischen den \glspl{OPC UA Client} und \glslink{OPC UA Server}{OPC UA Servern} fehl oder verliert mindestens ein \gls{OPC UA Client} die Verbindung zu seinem \gls{OPC UA Server}, wird 
+    der Benutzer über einen Dialog informiert und das Einstellungsfenster zur Eingabe der \gls{IP-Adresse} und Ports der \glspl{OPC UA Server} öffnet sich.
 \end{enumerate}
 
 \pagebreak


### PR DESCRIPTION
Sortiert. Endlich.
Optionale Funktionalität ist farblich markiert. Dies stört den Lesefluss weniger und während dem Lesen sieht man genau, welche FAs optional sind (momentan 18 von 83).