### PR TITLE
Improved readability of build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,6 @@ script:
 - cd src
 - mvn -U -B test
 - cd ../docs
-- pdflatex -interaction=batchmode Pflichtenheft
-- cat Pflichtenheft.log
+- export max_print_line=200
+- pdflatex -interaction=batchmode Pflichtenheft &> /dev/null
+- cat Pflichtenheft.log | grep -C 15 -i ERROR


### PR DESCRIPTION
Gerade wenn wir später noch mehr Output haben, stören 5.000 Zeilen LaTeX Output. Jetzt werden nur noch die errors angezeigt.