### PR TITLE
Checking line breaks and indentation

### DIFF
--- a/src/checkstyle.xml
+++ b/src/checkstyle.xml
@@ -4,6 +4,13 @@
   <property name="severity" value="warning"/>
   <module name="TreeWalker">
     <property name="tabWidth" value="4"/>
+    <module name="Indentation">
+      <property name="basicOffset" value="4"/>
+    </module>
+    <module name="RegexpMultiline">
+      <property name="format" value="(?s:(\r\n|\r).*)"/>
+      <property name="message" value="CRLF and CR line endings are prohibited, but this file uses them."/>
+    </module>
     <module name="JavadocType">
       <property name="scope" value="package"/>
     </module>


### PR DESCRIPTION
Diff ohne line break changes:
```
+    <module name="Indentation">
+      <property name="basicOffset" value="4"/>
+    </module>
+    <module name="RegexpMultiline">
+      <property name="format" value="(?s:(\r\n|\r).*)"/>
+      <property name="message" value="CRLF and CR line endings are prohibited, but this file uses them."/>
+    </module>
```