### PR TITLE
[core/model/behavior] Fix racecondition in scenario test

### DIFF
--- a/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/behavior/ScenarioTest.java
+++ b/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/behavior/ScenarioTest.java
@@ -111,6 +111,7 @@ public class ScenarioTest {
 
         try {
             assertEquals(true, future2.get(300, TimeUnit.MILLISECONDS));
+            sleep(50);
             assertFalse(scenario.isRunning());
         } catch (InterruptedException | ExecutionException | TimeoutException ex) {
             fail("CompletableFuture.get() failed: " + ex.getMessage());


### PR DESCRIPTION
Add a small delay after the execution of the last runnable, because
otherwise the scenario is still running sometimes.