### PR TITLE
[core/model/base] Reset the model without recreating the objects

### DIFF
--- a/src/osip-model-simulation/src/test/java/edu/kit/pse/osip/core/model/simulation/MixTankSimulationTest.java
+++ b/src/osip-model-simulation/src/test/java/edu/kit/pse/osip/core/model/simulation/MixTankSimulationTest.java
@@ -23,7 +23,8 @@ public class MixTankSimulationTest {
     @Test
     public void testPutIn() {
         Liquid content = new Liquid(100, 350, new Color(0x003000));
-        MixTankSimulation tank = new MixTankSimulation(1000, content, new Pipe(10, 10));
+        MixTankSimulation tank = new MixTankSimulation(1000, content, new Pipe(10, 10,
+            (byte) 100));
 
         LinkedList<Liquid> input = new LinkedList<>();
         input.add(new Liquid(100, 375, new Color(0x000000)));
@@ -39,7 +40,8 @@ public class MixTankSimulationTest {
     @Test
     public void testTakeOut() {
         Liquid content = new Liquid(100, 350, new Color(0x421337));
-        MixTankSimulation tank = new MixTankSimulation(1000, content, new Pipe(10, 10));
+        MixTankSimulation tank = new MixTankSimulation(1000, content, new Pipe(10, 10,
+            (byte) 100));
 
         Liquid out = tank.takeOut(33);
         assertEquals(new Liquid(33, 350, new Color(0x421337)), out);

--- a/src/osip-model-simulation/src/test/java/edu/kit/pse/osip/core/model/simulation/MixTankSimulationTest.java
+++ b/src/osip-model-simulation/src/test/java/edu/kit/pse/osip/core/model/simulation/MixTankSimulationTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.LinkedList;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import edu.kit.pse.osip.core.model.base.Color;
@@ -17,14 +18,23 @@ import edu.kit.pse.osip.core.model.base.Pipe;
  * @version 1.0
  */
 public class MixTankSimulationTest {
+    private Pipe pipe;
+
+    /**
+     * Initialize the pipes.
+     */
+    @Before
+    public void init() {
+        pipe = new Pipe(200f, 30, (byte) 100);
+    }
+
     /**
      * Test putting in some liquid
      */
     @Test
     public void testPutIn() {
         Liquid content = new Liquid(100, 350, new Color(0x003000));
-        MixTankSimulation tank = new MixTankSimulation(1000, content, new Pipe(10, 10,
-            (byte) 100));
+        MixTankSimulation tank = new MixTankSimulation(1000, content, pipe);
 
         LinkedList<Liquid> input = new LinkedList<>();
         input.add(new Liquid(100, 375, new Color(0x000000)));
@@ -40,8 +50,7 @@ public class MixTankSimulationTest {
     @Test
     public void testTakeOut() {
         Liquid content = new Liquid(100, 350, new Color(0x421337));
-        MixTankSimulation tank = new MixTankSimulation(1000, content, new Pipe(10, 10,
-            (byte) 100));
+        MixTankSimulation tank = new MixTankSimulation(1000, content, pipe);
 
         Liquid out = tank.takeOut(33);
         assertEquals(new Liquid(33, 350, new Color(0x421337)), out);

--- a/src/osip-model-simulation/src/test/java/edu/kit/pse/osip/core/model/simulation/TankSimulationTest.java
+++ b/src/osip-model-simulation/src/test/java/edu/kit/pse/osip/core/model/simulation/TankSimulationTest.java
@@ -23,7 +23,8 @@ public class TankSimulationTest {
     public void testPutIn() {
         Liquid content = new Liquid(100, 350, new Color(0x004000));
         TankSimulation tank = new TankSimulation(1000,
-                TankSelector.valuesWithoutMix()[0], content, new Pipe(10, 10), new Pipe(10, 10));
+                TankSelector.valuesWithoutMix()[0], content, new Pipe(10, 10, (byte) 100), new Pipe(
+                    10, 10, (byte) 100));
 
         tank.putIn(new Liquid(100,  310, new Color(0x800020)));
         assertEquals(new Liquid(200, 330, new Color(0x402010)), tank.getLiquid());
@@ -36,7 +37,8 @@ public class TankSimulationTest {
     public void testTakeOut() {
         Liquid content = new Liquid(100, 350, new Color(0x421337));
         TankSimulation tank = new TankSimulation(1000,
-                TankSelector.valuesWithoutMix()[0], content, new Pipe(10, 10), new Pipe(10, 10));
+                TankSelector.valuesWithoutMix()[0], content, new Pipe(10, 10, (byte) 100), new Pipe(
+                    10, 10, (byte) 100));
 
         Liquid out = tank.takeOut(33);
         assertEquals(new Liquid(33, 350, new Color(0x421337)), out);

--- a/src/osip-model-simulation/src/test/java/edu/kit/pse/osip/core/model/simulation/TankSimulationTest.java
+++ b/src/osip-model-simulation/src/test/java/edu/kit/pse/osip/core/model/simulation/TankSimulationTest.java
@@ -2,6 +2,7 @@ package edu.kit.pse.osip.core.model.simulation;
 
 import static org.junit.Assert.assertEquals;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import edu.kit.pse.osip.core.model.base.Color;
@@ -16,6 +17,18 @@ import edu.kit.pse.osip.core.model.base.TankSelector;
  * @version 1.0
  */
 public class TankSimulationTest {
+    private Pipe pipe1;
+    private Pipe pipe2;
+
+    /**
+     * Initialize the pipes.
+     */
+    @Before
+    public void init() {
+        pipe1 = new Pipe(200f, 30, (byte) 100);
+        pipe2 = new Pipe(200f, 30, (byte) 100);
+    }
+
     /**
      * Test putting in some liquid
      */
@@ -23,8 +36,7 @@ public class TankSimulationTest {
     public void testPutIn() {
         Liquid content = new Liquid(100, 350, new Color(0x004000));
         TankSimulation tank = new TankSimulation(1000,
-                TankSelector.valuesWithoutMix()[0], content, new Pipe(10, 10, (byte) 100), new Pipe(
-                    10, 10, (byte) 100));
+                TankSelector.valuesWithoutMix()[0], content, pipe1, pipe2);
 
         tank.putIn(new Liquid(100,  310, new Color(0x800020)));
         assertEquals(new Liquid(200, 330, new Color(0x402010)), tank.getLiquid());
@@ -37,8 +49,7 @@ public class TankSimulationTest {
     public void testTakeOut() {
         Liquid content = new Liquid(100, 350, new Color(0x421337));
         TankSimulation tank = new TankSimulation(1000,
-                TankSelector.valuesWithoutMix()[0], content, new Pipe(10, 10, (byte) 100), new Pipe(
-                    10, 10, (byte) 100));
+                TankSelector.valuesWithoutMix()[0], content, pipe1, pipe2);
 
         Liquid out = tank.takeOut(33);
         assertEquals(new Liquid(33, 350, new Color(0x421337)), out);

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/AbstractTank.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/AbstractTank.java
@@ -11,6 +11,7 @@ public abstract class AbstractTank extends java.util.Observable {
     private float capacity;
     private TankSelector selector;
     private Pipe outPipe;
+    private Liquid initialLiquid;
 
     /**
      * Create a new tank.
@@ -29,6 +30,7 @@ public abstract class AbstractTank extends java.util.Observable {
         }
         this.capacity = capacity;
         this.selector = tankSelector;
+        this.initialLiquid = liquid;
         this.liquid = liquid;
         this.outPipe = outPipe;
     }
@@ -77,5 +79,13 @@ public abstract class AbstractTank extends java.util.Observable {
      */
     public Liquid getLiquid() {
         return liquid;
+    }
+
+    /**
+     * Resets the tank and all attached units like pipes or motors.
+     */
+    public void reset() {
+        setLiquid(initialLiquid);
+        outPipe.reset();
     }
 }

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/AbstractTank.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/AbstractTank.java
@@ -84,7 +84,7 @@ public abstract class AbstractTank extends java.util.Observable {
     /**
      * Resets the tank and all attached units like pipes or motors.
      */
-    public void reset() {
+    public synchronized void reset() {
         setLiquid(initialLiquid);
         outPipe.reset();
     }

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Color.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Color.java
@@ -5,7 +5,7 @@ package edu.kit.pse.osip.core.model.base;
  * @author David Kahles
  * @version 1.0
  */
-public class Color implements Cloneable {
+public class Color {
     private double cyan;
     private double yellow;
     private double magenta;
@@ -134,20 +134,5 @@ public class Color implements Cloneable {
         result = 31 * result + (int) Math.round(magenta * 10000);
         result = 31 * result + (int) Math.round(yellow * 10000);
         return result;
-    }
-
-    @Override
-    public Color clone() {
-        Color tmp;
-        try {
-            tmp = (Color) super.clone();
-        } catch (CloneNotSupportedException ex) {
-            /* Should never happen */
-            throw new RuntimeException("Error in Color.clone()");
-        }
-        tmp.cyan = cyan;
-        tmp.magenta = magenta;
-        tmp.yellow = yellow;
-        return tmp;
     }
 }

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Color.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Color.java
@@ -55,20 +55,6 @@ public class Color implements Cloneable {
     }
 
     /**
-     * Set the cyan percentage.
-     *
-     * @param cyan The percentage of the cyan color. It needs to be between 0 and 1.
-     * @throws IllegalArgumentException if cyan is smaller than 0 or greather than 1.
-     */
-    public final synchronized void setCyan(double cyan) {
-        if (cyan < 0 || cyan > 1) {
-            throw new IllegalArgumentException("cyan argument needs to be in range 0 to 1, but is " + cyan);
-        }
-
-        this.cyan = cyan;
-    }
-
-    /**
      * Get the magenta percentage.
      *
      * @return the percentage of the magenta color.
@@ -78,40 +64,12 @@ public class Color implements Cloneable {
     }
 
     /**
-     * Set the magenta percentage.
-     *
-     * @param magenta The percentage of the magenta color. It needs to be between 0 and 1.
-     * @throws IllegalArgumentException if magenta is smaller than 0 or greather than 1.
-     */
-    public final synchronized void setMagenta(double magenta) {
-        if (magenta < 0 || magenta > 1) {
-            throw new IllegalArgumentException("magenta argument needs to be in range 0 to 1, but is " + magenta);
-        }
-
-        this.magenta = magenta;
-    }
-
-    /**
      * Get the yellow percentage.
      *
      * @return the percentage of the yellow color.
      */
     public final double getYellow() {
         return yellow;
-    }
-
-    /**
-     * Set the yellow percentage.
-     *
-     * @param yellow The percentage of the yellow color. It needs to be between 0 and 1.
-     * @throws IllegalArgumentException if yellow is smaller than 0 or greather than 1.
-     */
-    public final synchronized void setYellow(double yellow) {
-        if (yellow < 0 || yellow > 1) {
-            throw new IllegalArgumentException("yellow argument needs to be in range 0 to 1, but is " + yellow);
-        }
-
-        this.yellow = yellow;
     }
 
     /**
@@ -187,9 +145,9 @@ public class Color implements Cloneable {
             /* Should never happen */
             throw new RuntimeException("Error in Color.clone()");
         }
-        tmp.setCyan(cyan);
-        tmp.setMagenta(magenta);
-        tmp.setYellow(yellow);
+        tmp.cyan = cyan;
+        tmp.magenta = magenta;
+        tmp.yellow = yellow;
         return tmp;
     }
 }

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/MixTank.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/MixTank.java
@@ -26,4 +26,11 @@ public class MixTank extends edu.kit.pse.osip.core.model.base.AbstractTank {
     public Motor getMotor() {
         return motor;
     }
+
+    @Override
+    public void reset() {
+        super.reset();
+        motor.reset();
+    }
+
 }

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/MixTank.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/MixTank.java
@@ -16,7 +16,7 @@ public class MixTank extends edu.kit.pse.osip.core.model.base.AbstractTank {
      */
     public MixTank(float capacity, Liquid liquid, Pipe outPipe) {
         super(capacity, TankSelector.MIX, liquid, outPipe);
-        motor = new Motor();
+        motor = new Motor(0);
     }
 
     /**
@@ -32,5 +32,4 @@ public class MixTank extends edu.kit.pse.osip.core.model.base.AbstractTank {
         super.reset();
         motor.reset();
     }
-
 }

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/MixTank.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/MixTank.java
@@ -28,7 +28,7 @@ public class MixTank extends edu.kit.pse.osip.core.model.base.AbstractTank {
     }
 
     @Override
-    public void reset() {
+    public synchronized void reset() {
         super.reset();
         motor.reset();
     }

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Motor.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Motor.java
@@ -9,6 +9,15 @@ import edu.kit.pse.osip.core.SimulationConstants;
  */
 public class Motor extends java.util.Observable {
     private int rpm;
+    private int initialRpm;
+
+    /**
+     * Constructs a new Motor
+     * @param initialRpm The initial motor speed, which is also set when the motor gets reseted.
+     */
+    public Motor(int initialRpm) {
+        this.initialRpm = initialRpm;
+    }
 
     /**
      * Set the RPM of the motor.
@@ -32,9 +41,9 @@ public class Motor extends java.util.Observable {
     }
 
     /**
-     * Resets the Motor.
+     * Resets the Motor to @see initialRpm.
      */
     public synchronized void reset() {
-        setRPM(0);
+        setRPM(initialRpm);
     }
 }

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Motor.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Motor.java
@@ -20,6 +20,8 @@ public class Motor extends java.util.Observable {
             throw new IllegalArgumentException("Motor RPM needs to be in range 0 to 3000");
         }
         this.rpm = rpm;
+        setChanged();
+        notifyObservers();
     }
     /**
      * Get the RPM.

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Motor.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Motor.java
@@ -15,7 +15,7 @@ public class Motor extends java.util.Observable {
      * @throws IllegalArgumentException if rpm is negative or greater than SimulationConstants.MAX_MOTOR_SPEED.
      * @param rpm The target RPM.
      */
-    public final void setRPM(int rpm) {
+    public synchronized void setRPM(int rpm) {
         if (rpm < 0 || rpm > SimulationConstants.MAX_MOTOR_SPEED) {
             throw new IllegalArgumentException("Motor RPM needs to be in range 0 to 3000");
         }
@@ -27,14 +27,14 @@ public class Motor extends java.util.Observable {
      * Get the RPM.
      * @return the RPM.
      */
-    public final int getRPM() {
+    public int getRPM() {
         return rpm;
     }
 
     /**
      * Resets the Motor.
      */
-    public void reset() {
+    public synchronized void reset() {
         setRPM(0);
     }
 }

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Motor.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Motor.java
@@ -28,4 +28,11 @@ public class Motor extends java.util.Observable {
     public final int getRPM() {
         return rpm;
     }
+
+    /**
+     * Resets the Motor.
+     */
+    public void reset() {
+        setRPM(0);
+    }
 }

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Pipe.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Pipe.java
@@ -101,7 +101,7 @@ public class Pipe extends java.util.Observable {
     /**
      * Resets the Pipe.
      */
-    public void reset() {
+    public synchronized void reset() {
         threshold = defaultThreshold;
         queue.clear();
         setChanged();

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Pipe.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Pipe.java
@@ -15,6 +15,7 @@ public class Pipe extends java.util.Observable {
     private int length;
     private Queue<Liquid> queue = new LinkedBlockingQueue<>();
     private byte threshold = 100; /* in percent */
+    private byte defaultThreshold;
 
     /**
      * Construct a Pipe.
@@ -28,7 +29,26 @@ public class Pipe extends java.util.Observable {
         }
         this.crosssection = crosssection;
         this.length = length;
+        defaultThreshold = (byte) 100;
     }
+
+    /**
+     * Construct a Pipe.
+     * @param crosssection Crosssection of the pipe in cm².
+     * @param length Length in cm.
+     * @param defaultThreshold The default threshold
+     * @throws IllegalArgumentException if crosssection or length are negative or zero.
+     */
+    public Pipe(float crosssection, int length, byte defaultThreshold) {
+        if (crosssection <= 0 || length <= 0) {
+            throw new IllegalArgumentException("Crosssection and length of a pipe need to be greather than zero");
+        }
+        this.crosssection = crosssection;
+        this.defaultThreshold = defaultThreshold;
+        this.threshold = defaultThreshold;
+        this.length = length;
+    }
+
     /**
      * Insert liquid into one SimulationConstants.SIMULATION_STEP of the pipe and take out the liquid at the other side,
      * which gets pushed out.
@@ -91,5 +111,15 @@ public class Pipe extends java.util.Observable {
      */
     public float getMaxInputWithFullyOpenedValve() {
         return crosssection * SimulationConstants.SIMULATION_STEP;
+    }
+
+    /**
+     * Resets the Pipe.
+     */
+    public void reset() {
+        threshold = defaultThreshold;
+        queue.clear();
+        setChanged();
+        notifyObservers();
     }
 }

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Pipe.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Pipe.java
@@ -21,21 +21,6 @@ public class Pipe extends java.util.Observable {
      * Construct a Pipe.
      * @param crosssection Crosssection of the pipe in cm².
      * @param length Length in cm.
-     * @throws IllegalArgumentException if crosssection or length are negative or zero.
-     */
-    public Pipe(float crosssection, int length) {
-        if (crosssection <= 0 || length <= 0) {
-            throw new IllegalArgumentException("Crosssection and length of a pipe need to be greather than zero");
-        }
-        this.crosssection = crosssection;
-        this.length = length;
-        defaultThreshold = (byte) 100;
-    }
-
-    /**
-     * Construct a Pipe.
-     * @param crosssection Crosssection of the pipe in cm².
-     * @param length Length in cm.
      * @param defaultThreshold The default threshold
      * @throws IllegalArgumentException if crosssection or length are negative or zero.
      */

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/ProductionSite.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/ProductionSite.java
@@ -80,24 +80,25 @@ public class ProductionSite {
 
         mixTank = instantiateMixTank(SimulationConstants.TANK_SIZE, new Liquid(halfFull,
                 SimulationConstants.MIN_TEMPERATURE, TankSelector.MIX.getInitialColor()),
-                new Pipe(SimulationConstants.PIPE_CROSSSECTION, SimulationConstants.PIPE_LENGTH));
+                new Pipe(SimulationConstants.PIPE_CROSSSECTION, SimulationConstants.PIPE_LENGTH, (byte) 100));
+        inputTemperature.put(TankSelector.MIX, TankSelector.MIX.getInitialTemperature());
 
         boolean specialPipeAssigned = false;  /* One of the pipes needs to be set to 34 instead of 33 */
         for (TankSelector selector: TankSelector.valuesWithoutMix()) {
-            Liquid l = new Liquid(halfFull, SimulationConstants.MIN_TEMPERATURE, selector.getInitialColor());
-            Pipe inPipe = new Pipe(SimulationConstants.PIPE_CROSSSECTION, SimulationConstants.PIPE_LENGTH);
-            Pipe outPipe = new Pipe(SimulationConstants.PIPE_CROSSSECTION, SimulationConstants.PIPE_LENGTH);
-
+            byte threshold;
             if (!specialPipeAssigned) {
-                inPipe.setValveThreshold((byte) 34);
-                outPipe.setValveThreshold((byte) 34);
+                threshold = (byte) 34;
                 specialPipeAssigned = true;
             } else {
-                inPipe.setValveThreshold((byte) 33);
-                outPipe.setValveThreshold((byte) 33);
+                threshold = (byte) 33;
             }
+            Liquid l = new Liquid(halfFull, SimulationConstants.MIN_TEMPERATURE, selector.getInitialColor());
+            Pipe inPipe = new Pipe(SimulationConstants.PIPE_CROSSSECTION, SimulationConstants.PIPE_LENGTH, threshold);
+            Pipe outPipe = new Pipe(SimulationConstants.PIPE_CROSSSECTION, SimulationConstants.PIPE_LENGTH, threshold);
+
 
             tanks.put(selector, instantiateTank(SimulationConstants.TANK_SIZE, selector, l, outPipe, inPipe));
+            inputTemperature.put(selector, selector.getInitialTemperature());
         }
     }
 
@@ -123,6 +124,11 @@ public class ProductionSite {
      * a stable state.
      */
     public void reset() {
-        initTanks();
+        for (TankSelector selector: TankSelector.valuesWithoutMix()) {
+            tanks.get(selector).reset();
+            inputTemperature.put(selector, selector.getInitialTemperature());
+        }
+        mixTank.reset();
+        inputTemperature.put(TankSelector.MIX, TankSelector.MIX.getInitialTemperature());
     }
 }

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/ProductionSite.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/ProductionSite.java
@@ -12,8 +12,9 @@ import java.util.EnumMap;
  */
 public class ProductionSite {
     protected MixTank mixTank;
-    final protected EnumMap<TankSelector, Tank> tanks = new EnumMap<>(TankSelector.class);;
-    final protected EnumMap<TankSelector, Float> inputTemperature = new EnumMap<TankSelector, Float>(TankSelector.class);
+    protected final EnumMap<TankSelector, Tank> tanks = new EnumMap<>(TankSelector.class);;
+    protected final EnumMap<TankSelector, Float> inputTemperature
+        = new EnumMap<TankSelector, Float>(TankSelector.class);
 
     /**
      * Template method to allow subclasses to create objects of subclasses of Tank. The parameters are the same

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/ProductionSite.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/ProductionSite.java
@@ -125,7 +125,7 @@ public class ProductionSite {
      * Reset the whole production site to its default values: Every tank with 50% infill, valves putting the site to
      * a stable state.
      */
-    public void reset() {
+    public synchronized void reset() {
         for (TankSelector selector: TankSelector.valuesWithoutMix()) {
             tanks.get(selector).reset();
             inputTemperature.put(selector, selector.getInitialTemperature());

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/ProductionSite.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/ProductionSite.java
@@ -12,8 +12,8 @@ import java.util.EnumMap;
  */
 public class ProductionSite {
     protected MixTank mixTank;
-    protected EnumMap<TankSelector, Tank> tanks;
-    protected EnumMap<TankSelector, Float> inputTemperature;
+    protected EnumMap<TankSelector, Tank> tanks = new EnumMap<>(TankSelector.class);;
+    protected EnumMap<TankSelector, Float> inputTemperature = new EnumMap<TankSelector, Float>(TankSelector.class);
 
     /**
      * Template method to allow subclasses to create objects of subclasses of Tank. The parameters are the same
@@ -83,7 +83,6 @@ public class ProductionSite {
                 new Pipe(SimulationConstants.PIPE_CROSSSECTION, SimulationConstants.PIPE_LENGTH));
 
         boolean specialPipeAssigned = false;  /* One of the pipes needs to be set to 34 instead of 33 */
-        tanks = new EnumMap<>(TankSelector.class);
         for (TankSelector selector: TankSelector.valuesWithoutMix()) {
             Liquid l = new Liquid(halfFull, SimulationConstants.MIN_TEMPERATURE, selector.getInitialColor());
             Pipe inPipe = new Pipe(SimulationConstants.PIPE_CROSSSECTION, SimulationConstants.PIPE_LENGTH);

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/ProductionSite.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/ProductionSite.java
@@ -79,9 +79,8 @@ public class ProductionSite {
         int halfFull = SimulationConstants.TANK_SIZE / 2;
 
         mixTank = instantiateMixTank(SimulationConstants.TANK_SIZE, new Liquid(halfFull,
-                SimulationConstants.MIN_TEMPERATURE, TankSelector.MIX.getInitialColor()),
+                TankSelector.MIX.getInitialTemperature(), TankSelector.MIX.getInitialColor()),
                 new Pipe(SimulationConstants.PIPE_CROSSSECTION, SimulationConstants.PIPE_LENGTH, (byte) 100));
-        inputTemperature.put(TankSelector.MIX, TankSelector.MIX.getInitialTemperature());
 
         boolean specialPipeAssigned = false;  /* One of the pipes needs to be set to 34 instead of 33 */
         for (TankSelector selector: TankSelector.valuesWithoutMix()) {
@@ -92,14 +91,16 @@ public class ProductionSite {
             } else {
                 threshold = (byte) 33;
             }
-            Liquid l = new Liquid(halfFull, SimulationConstants.MIN_TEMPERATURE, selector.getInitialColor());
+            Liquid l = new Liquid(halfFull, selector.getInitialTemperature(), selector.getInitialColor());
             Pipe inPipe = new Pipe(SimulationConstants.PIPE_CROSSSECTION, SimulationConstants.PIPE_LENGTH, threshold);
             Pipe outPipe = new Pipe(SimulationConstants.PIPE_CROSSSECTION, SimulationConstants.PIPE_LENGTH, threshold);
 
 
             tanks.put(selector, instantiateTank(SimulationConstants.TANK_SIZE, selector, l, outPipe, inPipe));
-            inputTemperature.put(selector, selector.getInitialTemperature());
         }
+
+        /* Make sure we're in the correct state */
+        reset();
     }
 
     /**

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/ProductionSite.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/ProductionSite.java
@@ -12,8 +12,8 @@ import java.util.EnumMap;
  */
 public class ProductionSite {
     protected MixTank mixTank;
-    protected EnumMap<TankSelector, Tank> tanks = new EnumMap<>(TankSelector.class);;
-    protected EnumMap<TankSelector, Float> inputTemperature = new EnumMap<TankSelector, Float>(TankSelector.class);
+    final protected EnumMap<TankSelector, Tank> tanks = new EnumMap<>(TankSelector.class);;
+    final protected EnumMap<TankSelector, Float> inputTemperature = new EnumMap<TankSelector, Float>(TankSelector.class);
 
     /**
      * Template method to allow subclasses to create objects of subclasses of Tank. The parameters are the same

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Tank.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Tank.java
@@ -35,4 +35,10 @@ public class Tank extends AbstractTank {
     public Pipe getInPipe() {
         return inPipe;
     }
+
+    @Override
+    public void reset() {
+        super.reset();
+        inPipe.reset();
+    }
 }

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Tank.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Tank.java
@@ -37,7 +37,7 @@ public class Tank extends AbstractTank {
     }
 
     @Override
-    public void reset() {
+    public synchronized void reset() {
         super.reset();
         inPipe.reset();
     }

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/TankSelector.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/TankSelector.java
@@ -39,11 +39,29 @@ public enum TankSelector {
     };
 
     /**
+     * This array defines the initial temperatures in the same order as the tanks are defined above.
+     */
+    private static float[] initialTemperatures = {
+            300,
+            300,
+            300,
+            300,
+    };
+
+    /**
      * Get the initial color of a tank.
      * @return The initial color of a tank.
      */
     public Color getInitialColor() {
         return initialColors[this.ordinal()].clone();
+    }
+
+    /**
+     * Get the initial temperature of a tank.
+     * @return The initial temperature of a tank.
+     */
+    public float getInitialTemperature() {
+        return initialTemperatures[this.ordinal()];
     }
     
     /**

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/TankSelector.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/TankSelector.java
@@ -33,9 +33,9 @@ public enum TankSelector {
      */
     private static Color[] initialColors = {
         new Color(1, 1, 1),
-        new Color(0, 1, 0),
-        new Color(1, 0, 0),
         new Color(0, 0, 1),
+        new Color(1, 0, 0),
+        new Color(0, 1, 0),
     };
 
     /**

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/TankSelector.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/TankSelector.java
@@ -53,7 +53,7 @@ public enum TankSelector {
      * @return The initial color of a tank.
      */
     public Color getInitialColor() {
-        return initialColors[this.ordinal()].clone();
+        return initialColors[this.ordinal()];
     }
 
     /**

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/TankSelector.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/TankSelector.java
@@ -42,10 +42,10 @@ public enum TankSelector {
      * This array defines the initial temperatures in the same order as the tanks are defined above.
      */
     private static float[] initialTemperatures = {
-            300,
-            300,
-            300,
-            300,
+        300,
+        300,
+        300,
+        300,
     };
 
     /**

--- a/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/ColorTest.java
+++ b/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/ColorTest.java
@@ -95,71 +95,6 @@ public class ColorTest {
     }
 
     /**
-     * Check whether the setters reject illegal arguments.
-     */
-    @Test
-    public void testWrongArgumentsSetter() {
-        Color color = new Color(1, 1, 1);
-        try {
-            color.setCyan(-1);
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            // Expected
-        }
-        try {
-            color.setCyan(2);
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            // Expected
-        }
-        try {
-            color.setMagenta(-1);
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            // Expected
-        }
-        try {
-            color.setMagenta(2);
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            // Expected
-        }
-        try {
-            color.setYellow(-1);
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            // Expected
-        }
-        try {
-            color.setYellow(2);
-            fail("Expected IllegalArgumentException");
-        } catch (IllegalArgumentException e) {
-            // Expected
-        }
-    }
-
-    /**
-     * Check whether the setters accept correct arguments.
-     */
-    @Test
-    public void testSetter() {
-        Color color = new Color(0.5, 0.5, 0.5);
-        color.setCyan(0);
-        assertEquals(0, color.getCyan(), epsilon);
-        color.setMagenta(0);
-        assertEquals(0, color.getMagenta(), epsilon);
-        color.setYellow(0);
-        assertEquals(0, color.getYellow(), epsilon);
-
-        color.setCyan(1);
-        assertEquals(1, color.getCyan(), epsilon);
-        color.setMagenta(1);
-        assertEquals(1, color.getMagenta(), epsilon);
-        color.setYellow(1);
-        assertEquals(1, color.getYellow(), epsilon);
-    }
-
-    /**
      * Check whether the equals method works as expected.
      */
     @Test
@@ -170,7 +105,7 @@ public class ColorTest {
         assertTrue(color2.equals(color1));
         assertFalse(color1.equals(null));
         assertFalse(color1.equals(new String("test")));
-        color2.setYellow(0.6);
+        color2 = new Color(0.5, 0.5, 0.6);
         assertFalse(color1.equals(color2));
         assertFalse(color2.equals(color1));
     }
@@ -183,7 +118,7 @@ public class ColorTest {
         Color color1 = new Color(0.5, 0.5, 0.5);
         Color color2 = new Color(0.5, 0.5, 0.5);
         assertEquals(color1.hashCode(), color2.hashCode());
-        color2.setYellow(0.2);
+        color2 = new Color(0.5, 0.5, 0.6);
         assertNotEquals(color1.hashCode(), color2.hashCode());
     }
 

--- a/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/ColorTest.java
+++ b/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/ColorTest.java
@@ -133,18 +133,4 @@ public class ColorTest {
         assertEquals(61 / 255f, color.getG(), 0.01);
         assertEquals(148 / 255f, color.getB(), 0.01);
     }
-
-    /**
-     * Test whether clone() works correctly
-     * @throws CloneNotSupportedException if clone() is implemented wrong.
-     */
-    @Test
-    public void testClone() throws CloneNotSupportedException {
-        Color color = new Color(0.54, 0.76, 0.42);
-        assertTrue(color.equals(color.clone()));
-        assertFalse(color == color.clone());
-        assertTrue(color.getClass() == color.clone().getClass());
-
-    }
-
 }

--- a/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/MixTankTest.java
+++ b/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/MixTankTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertTrue;
  */
 public class MixTankTest implements Observer {
     private Liquid liquid = new Liquid(1, SimulationConstants.MIN_TEMPERATURE, new Color(0));
-    private Pipe outPipe = new Pipe(5, 5);
+    private Pipe outPipe = new Pipe(5, 5, (byte) 100);
     private boolean changed;
 
     /**

--- a/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/MotorTest.java
+++ b/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/MotorTest.java
@@ -1,10 +1,13 @@
 package edu.kit.pse.osip.core.model.base;
 
 import edu.kit.pse.osip.core.SimulationConstants;
+import java.util.Observable;
+import java.util.Observer;
 import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * A class to test the Motor class.
@@ -12,8 +15,9 @@ import static org.junit.Assert.assertEquals;
  * @author David Kahles
  * @version 1.0
  */
-public class MotorTest {
-    Motor motor = null;
+public class MotorTest implements Observer {
+    private Motor motor = null;
+    private boolean observed;
 
     /**
      * Create a new Motor for tests.
@@ -21,6 +25,7 @@ public class MotorTest {
     @Before
     public void initMotor() {
         motor = new Motor();
+        observed = false;
     }
 
     /**
@@ -48,5 +53,20 @@ public class MotorTest {
         assertEquals(0, motor.getRPM());
         motor.setRPM(SimulationConstants.MAX_MOTOR_SPEED);
         assertEquals(SimulationConstants.MAX_MOTOR_SPEED, motor.getRPM());
+    }
+
+    /**
+     * Test whether observing the motor works fine.
+     */
+    @Test
+    public void testObserver() {
+        motor.addObserver(this);
+        motor.setRPM(5);
+        assertTrue(observed);
+    }
+
+    @Override
+    public void update(Observable observable, Object o) {
+        observed = true;
     }
 }

--- a/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/MotorTest.java
+++ b/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/MotorTest.java
@@ -24,7 +24,7 @@ public class MotorTest implements Observer {
      */
     @Before
     public void initMotor() {
-        motor = new Motor();
+        motor = new Motor(0);
         observed = false;
     }
 
@@ -51,8 +51,11 @@ public class MotorTest implements Observer {
     public void testSet() {
         motor.setRPM(0);
         assertEquals(0, motor.getRPM());
+        motor = new Motor(SimulationConstants.MAX_MOTOR_SPEED - 1);
         motor.setRPM(SimulationConstants.MAX_MOTOR_SPEED);
         assertEquals(SimulationConstants.MAX_MOTOR_SPEED, motor.getRPM());
+        motor.reset();
+        assertEquals(SimulationConstants.MAX_MOTOR_SPEED - 1, motor.getRPM());
     }
 
     /**

--- a/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/PipeTest.java
+++ b/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/PipeTest.java
@@ -16,15 +16,15 @@ import static org.junit.Assert.assertTrue;
  * @version 1.0
  */
 public class PipeTest implements Observer {
-    Pipe pipe = null;
-    boolean changed;
+    private Pipe pipe = null;
+    private boolean changed;
 
     /**
      * Initialize the pipe and the changed boolean.
      */
     @Before
     public void init() {
-        pipe = new Pipe(5, 5);
+        pipe = new Pipe(5, 5, (byte) 100);
         changed = false;
     }
 
@@ -33,7 +33,7 @@ public class PipeTest implements Observer {
      */
     @Test(expected = IllegalArgumentException.class)
     public void wrongCrosssection() {
-        new Pipe(0, 5);
+        new Pipe(0, 5, (byte) 100);
     }
 
     /**
@@ -41,7 +41,7 @@ public class PipeTest implements Observer {
      */
     @Test(expected = IllegalArgumentException.class)
     public void wrongLength() {
-        new Pipe(5, 0);
+        new Pipe(5, 0, (byte) 100);
     }
 
     /**
@@ -111,7 +111,7 @@ public class PipeTest implements Observer {
      */
     @Test
     public void testPutInSmallPipe() {
-        pipe = new Pipe(1, 1);
+        pipe = new Pipe(1, 1, (byte) 100);
 
         Liquid empty = new Liquid(0, SimulationConstants.MIN_TEMPERATURE, new Color(0));
         Liquid l1 = new Liquid(pipe.getMaxInput() / 2, SimulationConstants.MIN_TEMPERATURE, new Color(0));

--- a/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/ProductionSiteTest.java
+++ b/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/ProductionSiteTest.java
@@ -1,5 +1,6 @@
 package edu.kit.pse.osip.core.model.base;
 
+import edu.kit.pse.osip.core.SimulationConstants;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -150,5 +151,30 @@ public class ProductionSiteTest {
         Color newColor = l.getColor();
         newColor.setCyan(0.8);
         return new Liquid(l.getAmount() + 1, l.getTemperature() + 2, newColor);
+    }
+
+    /**
+     * Test that the ProductionSite remembers temperatures
+     */
+    @Test
+    public void testInputTemperature() {
+        prodSite.setInputTemperature(TankSelector.MIX, SimulationConstants.MIN_TEMPERATURE);
+        assertEquals(SimulationConstants.MIN_TEMPERATURE, prodSite.getInputTemperature(TankSelector.MIX), 0.0001);
+    }
+
+    /**
+     * Test that the ProductionSite rejects too low temperatures
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testTooLowInputTemperature() {
+        prodSite.setInputTemperature(TankSelector.MIX, SimulationConstants.MIN_TEMPERATURE - 1);
+    }
+
+    /**
+     * Test that the ProductionSite rejects too high temperatures
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testTooHighInputTemperature() {
+        prodSite.setInputTemperature(TankSelector.MIX, SimulationConstants.MAX_TEMPERATURE + 1);
     }
 }

--- a/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/ProductionSiteTest.java
+++ b/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/ProductionSiteTest.java
@@ -148,9 +148,9 @@ public class ProductionSiteTest {
     }
 
     private Liquid modifyLiquid(Liquid l) {
-        Color newColor = l.getColor();
-        newColor.setCyan(0.8);
-        return new Liquid(l.getAmount() + 1, l.getTemperature() + 2, newColor);
+        Color c = l.getColor();
+        return new Liquid(l.getAmount() + 1, l.getTemperature() + 2, new Color(c.getCyan(),
+            c.getMagenta(), c.getYellow()));
     }
 
     /**

--- a/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/TankSelectorTest.java
+++ b/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/TankSelectorTest.java
@@ -4,6 +4,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * A class to test the TankSelector class.
@@ -34,13 +35,25 @@ public class TankSelectorTest {
     }
 
     /**
-     * Check whether getIntialColor() is correct. This test uses hardcoded tanks and color values.
+     * Check whether there are at least two tanks defined, one of them being the mix tank.
      */
     @Test
-    public void testGetInitialColor() {
-        assertEquals(TankSelector.MIX.getInitialColor(), new Color(1, 1, 1));
-        assertEquals(TankSelector.YELLOW.getInitialColor(), new Color(0, 0, 1));
-        assertEquals(TankSelector.MAGENTA.getInitialColor(), new Color(0, 1, 0));
-        assertEquals(TankSelector.CYAN.getInitialColor(), new Color(1, 0, 0));
+    public void testGEnoughTanks() {
+        /* TankSelector.MIX exists */
+        TankSelector testSelector = TankSelector.MIX;
+        assertTrue(TankSelector.valuesWithoutMix().length >= 1);
+        assertTrue(TankSelector.values().length >= 2);
+    }
+
+    /**
+     * Check whether getIntialColor() and getInitialTemperatue/( returns a value for every tank. Should not throw an
+     * ArrayIndexOutOfBoundsException.
+     */
+    @Test
+    public void testGetInitialColorTemperature() {
+        for (TankSelector selector: TankSelector.values()) {
+            selector.getInitialColor();
+            selector.getInitialTemperature();
+        }
     }
 }

--- a/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/TankSelectorTest.java
+++ b/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/TankSelectorTest.java
@@ -46,7 +46,7 @@ public class TankSelectorTest {
     }
 
     /**
-     * Check whether getIntialColor() and getInitialTemperatue/( returns a value for every tank. Should not throw an
+     * Check whether getIntialColor() and getInitialTemperatue() returns a value for every tank. Should not throw an
      * ArrayIndexOutOfBoundsException.
      */
     @Test

--- a/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/TankSelectorTest.java
+++ b/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/TankSelectorTest.java
@@ -39,8 +39,8 @@ public class TankSelectorTest {
     @Test
     public void testGetInitialColor() {
         assertEquals(TankSelector.MIX.getInitialColor(), new Color(1, 1, 1));
-        assertEquals(TankSelector.YELLOW.getInitialColor(), new Color(0, 1, 0));
-        assertEquals(TankSelector.MAGENTA.getInitialColor(), new Color(0, 0, 1));
+        assertEquals(TankSelector.YELLOW.getInitialColor(), new Color(0, 0, 1));
+        assertEquals(TankSelector.MAGENTA.getInitialColor(), new Color(0, 1, 0));
         assertEquals(TankSelector.CYAN.getInitialColor(), new Color(1, 0, 0));
     }
 }

--- a/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/TankTest.java
+++ b/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/TankTest.java
@@ -18,8 +18,8 @@ import static org.junit.Assert.assertTrue;
  */
 public class TankTest implements Observer {
     private Liquid liquid = new Liquid(1, SimulationConstants.MIN_TEMPERATURE, new Color(0));
-    private Pipe inPipe = new Pipe(5, 5);
-    private Pipe outPipe = new Pipe(5, 5);
+    private Pipe inPipe = new Pipe(5, 5, (byte) 100);
+    private Pipe outPipe = new Pipe(5, 5, (byte) 100);
     private boolean changed;
 
     /**

--- a/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/behavior/FillAlarmTest.java
+++ b/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/behavior/FillAlarmTest.java
@@ -2,6 +2,7 @@ package edu.kit.pse.osip.core.model.behavior;
 
 import static org.junit.Assert.assertEquals;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import edu.kit.pse.osip.core.model.base.Color;
@@ -21,6 +22,17 @@ public class FillAlarmTest {
     private Liquid testLiquid;
     private Tank tank;
     private FillAlarm alarm;
+    private Pipe pipe1;
+    private Pipe pipe2;
+
+    /**
+     * Initialize the pipes.
+     */
+    @Before
+    public void init() {
+        pipe1 = new Pipe(200f, 30, (byte) 100);
+        pipe2 = new Pipe(200f, 30, (byte) 100);
+    }
     
     /**
      * Test configuration where alarm is not triggered
@@ -28,8 +40,7 @@ public class FillAlarmTest {
     @Test
     public void testAlarmIsNotTriggered() {
         testLiquid = new Liquid(20f, 300f, new Color(0.5, 0.5, 0.5));
-        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquid, new Pipe(200f,
-            30, (byte) 100), new Pipe(200f, 30, (byte) 100));
+        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquid, pipe1, pipe2);
         alarm = new FillAlarm(tank, 50f, AlarmBehavior.GREATER_THAN);
         assertEquals(false, alarm.isAlarmTriggered());
     }
@@ -40,8 +51,7 @@ public class FillAlarmTest {
     @Test
     public void testAlarmIsTriggered() {
         testLiquid = new Liquid(101f, 300f, new Color(0.5, 0.5, 0.5));
-        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquid, new Pipe(200f,
-            30, (byte) 100), new Pipe(200f, 30, (byte) 100));
+        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquid, pipe1, pipe2);
         alarm = new FillAlarm(tank, 50f, AlarmBehavior.GREATER_THAN);
         assertEquals(true, alarm.isAlarmTriggered());
     }
@@ -52,8 +62,7 @@ public class FillAlarmTest {
     @Test
     public void testUnderFlowAlarm() {
         testLiquid = new Liquid(90f, 300f, new Color(0.5, 0.5, 0.5));
-        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquid, new Pipe(200f,
-            30, (byte) 100), new Pipe(200f, 30, (byte) 100));
+        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquid, pipe1, pipe2);
         alarm = new FillAlarm(tank, 50f, AlarmBehavior.SMALLER_THAN);
         assertEquals(true, alarm.isAlarmTriggered());
     }

--- a/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/behavior/FillAlarmTest.java
+++ b/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/behavior/FillAlarmTest.java
@@ -28,7 +28,8 @@ public class FillAlarmTest {
     @Test
     public void testAlarmIsNotTriggered() {
         testLiquid = new Liquid(20f, 300f, new Color(0.5, 0.5, 0.5));
-        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquid, new Pipe(200f, 30), new Pipe(200f, 30));
+        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquid, new Pipe(200f,
+            30, (byte) 100), new Pipe(200f, 30, (byte) 100));
         alarm = new FillAlarm(tank, 50f, AlarmBehavior.GREATER_THAN);
         assertEquals(false, alarm.isAlarmTriggered());
     }
@@ -39,7 +40,8 @@ public class FillAlarmTest {
     @Test
     public void testAlarmIsTriggered() {
         testLiquid = new Liquid(101f, 300f, new Color(0.5, 0.5, 0.5));
-        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquid, new Pipe(200f, 30), new Pipe(200f, 30));
+        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquid, new Pipe(200f,
+            30, (byte) 100), new Pipe(200f, 30, (byte) 100));
         alarm = new FillAlarm(tank, 50f, AlarmBehavior.GREATER_THAN);
         assertEquals(true, alarm.isAlarmTriggered());
     }
@@ -50,7 +52,8 @@ public class FillAlarmTest {
     @Test
     public void testUnderFlowAlarm() {
         testLiquid = new Liquid(90f, 300f, new Color(0.5, 0.5, 0.5));
-        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquid, new Pipe(200f, 30), new Pipe(200f, 30));
+        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquid, new Pipe(200f,
+            30, (byte) 100), new Pipe(200f, 30, (byte) 100));
         alarm = new FillAlarm(tank, 50f, AlarmBehavior.SMALLER_THAN);
         assertEquals(true, alarm.isAlarmTriggered());
     }

--- a/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/behavior/TankAlarmObservableTest.java
+++ b/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/behavior/TankAlarmObservableTest.java
@@ -26,6 +26,7 @@ public class TankAlarmObservableTest {
     private FillAlarm alarm;
     private Pipe pipe1;
     private Pipe pipe2;
+    private Color defaultColor = new Color(0.5, 0.5, 0.5);
     
    /**
     * Helper observer for tests
@@ -70,12 +71,12 @@ public class TankAlarmObservableTest {
      */
     @Test
     public void testObservableNotify() {       
-        testLiquid = new Liquid(150f, 300f, new Color(0.5, 0.5, 0.5));
+        testLiquid = new Liquid(150f, 300f, defaultColor);
         tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquid, pipe1, pipe2);
         alarm = new FillAlarm(tank, 50f, AlarmBehavior.GREATER_THAN);        
         TestObserver tObserver = new TestObserver();
         alarm.addObserver(tObserver);
-        Liquid alteredLiquid = new Liquid(50f, 300f, new Color(0.5, 0.5, 0.5));
+        Liquid alteredLiquid = new Liquid(50f, 300f, defaultColor);
         tank.setLiquid(alteredLiquid);
         assertEquals(true, tObserver.wasNotified());        
     }
@@ -85,12 +86,12 @@ public class TankAlarmObservableTest {
      */
     @Test
     public void testObservableNoNotify() {
-        testLiquid = new Liquid(50f, 300f, new Color(0.5, 0.5, 0.5));
+        testLiquid = new Liquid(50f, 300f, defaultColor);
         tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquid, pipe1, pipe2);
         alarm = new FillAlarm(tank, 50f, AlarmBehavior.GREATER_THAN);        
         TestObserver tObserver = new TestObserver();
         alarm.addObserver(tObserver);
-        Liquid alteredLiquid = new Liquid(80f, 300f, new Color(0.5, 0.5, 0.5));
+        Liquid alteredLiquid = new Liquid(80f, 300f, defaultColor);
         tank.setLiquid(alteredLiquid);
         assertEquals(false, tObserver.wasNotified());
     }    
@@ -100,9 +101,9 @@ public class TankAlarmObservableTest {
      */
     @Test
     public void testObservableNotifyMultiple() {       
-        Liquid testLiquidA = new Liquid(50f, 300f, new Color(0.5, 0.5, 0.5));
-        Liquid testLiquidB = new Liquid(150f, 300f, new Color(0.5, 0.5, 0.5));
-        Liquid testLiquidC = new Liquid(60f, 300f, new Color(0.5, 0.5, 0.5));
+        Liquid testLiquidA = new Liquid(50f, 300f, defaultColor);
+        Liquid testLiquidB = new Liquid(150f, 300f, defaultColor);
+        Liquid testLiquidC = new Liquid(60f, 300f, defaultColor);
         tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquidA, pipe1, pipe2);
         alarm = new FillAlarm(tank, 50f, AlarmBehavior.GREATER_THAN);        
         TestObserver tObserver = new TestObserver();
@@ -121,9 +122,9 @@ public class TankAlarmObservableTest {
      */
     @Test
     public void testObservbleNotifyMultipleConstant() {
-        Liquid testLiquidA = new Liquid(50f, 300f, new Color(0.5, 0.5, 0.5));
-        Liquid testLiquidB = new Liquid(150f, 300f, new Color(0.5, 0.5, 0.5));
-        Liquid testLiquidC = new Liquid(160f, 300f, new Color(0.5, 0.5, 0.5));
+        Liquid testLiquidA = new Liquid(50f, 300f, defaultColor);
+        Liquid testLiquidB = new Liquid(150f, 300f, defaultColor);
+        Liquid testLiquidC = new Liquid(160f, 300f, defaultColor);
         tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquidA, pipe1, pipe2);
         alarm = new FillAlarm(tank, 50f, AlarmBehavior.GREATER_THAN);        
         TestObserver tObserver = new TestObserver();

--- a/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/behavior/TankAlarmObservableTest.java
+++ b/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/behavior/TankAlarmObservableTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.Observable;
 import java.util.Observer;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import edu.kit.pse.osip.core.model.base.Color;
@@ -23,6 +24,8 @@ public class TankAlarmObservableTest {
     private Liquid testLiquid;
     private Tank tank;
     private FillAlarm alarm;
+    private Pipe pipe1;
+    private Pipe pipe2;
     
    /**
     * Helper observer for tests
@@ -31,10 +34,11 @@ public class TankAlarmObservableTest {
     */
     class TestObserver implements Observer {
         private boolean wasNotified = false;
+
         @Override
         public void update(Observable o, Object arg) {
-            wasNotified = true;                
-        }            
+            wasNotified = true;
+        }
     
         /**
          * Getter for notified 
@@ -49,8 +53,17 @@ public class TankAlarmObservableTest {
          */
         public void resetNotified() {
             wasNotified = false;
-        }       
-    }    
+        }
+    }
+
+    /**
+     * Intialize pipes
+     */
+    @Before
+    public void init() {
+        pipe1 = new Pipe(200f, 30, (byte) 100);
+        pipe2 = new Pipe(200f, 30, (byte) 100);
+    }
     
     /**
      * Test if alarm gives notification on changes
@@ -58,7 +71,7 @@ public class TankAlarmObservableTest {
     @Test
     public void testObservableNotify() {       
         testLiquid = new Liquid(150f, 300f, new Color(0.5, 0.5, 0.5));
-        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquid, new Pipe(200f, 30), new Pipe(200f, 30));
+        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquid, pipe1, pipe2);
         alarm = new FillAlarm(tank, 50f, AlarmBehavior.GREATER_THAN);        
         TestObserver tObserver = new TestObserver();
         alarm.addObserver(tObserver);
@@ -73,7 +86,7 @@ public class TankAlarmObservableTest {
     @Test
     public void testObservableNoNotify() {
         testLiquid = new Liquid(50f, 300f, new Color(0.5, 0.5, 0.5));
-        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquid, new Pipe(200f, 30), new Pipe(200f, 30));
+        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquid, pipe1, pipe2);
         alarm = new FillAlarm(tank, 50f, AlarmBehavior.GREATER_THAN);        
         TestObserver tObserver = new TestObserver();
         alarm.addObserver(tObserver);
@@ -90,7 +103,7 @@ public class TankAlarmObservableTest {
         Liquid testLiquidA = new Liquid(50f, 300f, new Color(0.5, 0.5, 0.5));
         Liquid testLiquidB = new Liquid(150f, 300f, new Color(0.5, 0.5, 0.5));
         Liquid testLiquidC = new Liquid(60f, 300f, new Color(0.5, 0.5, 0.5));
-        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquidA, new Pipe(200f, 30), new Pipe(200f, 30));
+        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquidA, pipe1, pipe2);
         alarm = new FillAlarm(tank, 50f, AlarmBehavior.GREATER_THAN);        
         TestObserver tObserver = new TestObserver();
         alarm.addObserver(tObserver);
@@ -111,7 +124,7 @@ public class TankAlarmObservableTest {
         Liquid testLiquidA = new Liquid(50f, 300f, new Color(0.5, 0.5, 0.5));
         Liquid testLiquidB = new Liquid(150f, 300f, new Color(0.5, 0.5, 0.5));
         Liquid testLiquidC = new Liquid(160f, 300f, new Color(0.5, 0.5, 0.5));
-        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquidA, new Pipe(200f, 30), new Pipe(200f, 30));
+        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquidA, pipe1, pipe2);
         alarm = new FillAlarm(tank, 50f, AlarmBehavior.GREATER_THAN);        
         TestObserver tObserver = new TestObserver();
         alarm.addObserver(tObserver);

--- a/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/behavior/TemperatureAlarmTest.java
+++ b/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/behavior/TemperatureAlarmTest.java
@@ -2,6 +2,7 @@ package edu.kit.pse.osip.core.model.behavior;
 
 import static org.junit.Assert.assertEquals;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import edu.kit.pse.osip.core.model.base.Color;
@@ -21,6 +22,17 @@ public class TemperatureAlarmTest {
     private Liquid testLiquid;
     private Tank tank;
     private TemperatureAlarm alarm;
+    private Pipe pipe1;
+    private Pipe pipe2;
+
+    /**
+     * Intialize pipes
+     */
+    @Before
+    public void init() {
+        pipe1 = new Pipe(200f, 30, (byte) 100);
+        pipe2 = new Pipe(200f, 30, (byte) 100);
+    }
     
     /**
      * Test configuration where alarm is not triggered
@@ -28,7 +40,7 @@ public class TemperatureAlarmTest {
     @Test
     public void testAlarmIsNotTriggered() {
         testLiquid = new Liquid(20f, 300f, new Color(0.5, 0.5, 0.5));
-        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquid, new Pipe(200f, 30), new Pipe(200f, 30));
+        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquid, pipe1, pipe2);
         alarm = new TemperatureAlarm(tank, 400f, AlarmBehavior.GREATER_THAN);
         assertEquals(false, alarm.isAlarmTriggered());
     }
@@ -39,7 +51,7 @@ public class TemperatureAlarmTest {
     @Test
     public void testAlarmIsTriggered() {
         testLiquid = new Liquid(20f, 300f, new Color(0.5, 0.5, 0.5));
-        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquid, new Pipe(200f, 30), new Pipe(200f, 30));
+        tank = new Tank(200f, TankSelector.valuesWithoutMix()[0], testLiquid, pipe1, pipe2);
         alarm = new TemperatureAlarm(tank, 200f, AlarmBehavior.GREATER_THAN);
         assertEquals(true, alarm.isAlarmTriggered());
     }


### PR DESCRIPTION
Thus the observers of the model don't need to resubscribe to all tanks, pipes and motors.
Also fix a bug, where the motor hasn't notified the observers.