### PR TITLE
[simulation/view] Make resize timer a daemon

### DIFF
--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMainWindow.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMainWindow.java
@@ -250,7 +250,7 @@ public class SimulationMainWindow implements SimulationViewInterface, Observer {
     private void setResizeListeners(Stage primaryStage) {
 
         final ChangeListener<Number> listener = new ChangeListener<Number>() {
-            final Timer timer = new Timer();
+            final Timer timer = new Timer(true);
             TimerTask task = null;
             final long delayTime = 50;
 


### PR DESCRIPTION
Otherwise it will block the application to quit.
Ich weiß nicht warum der Thread nicht garbage collected wird, nach dem das Fenster geschlossen wurde. Habt ihr Ideen?