### PR TITLE
Simulation control fix

### DIFF
--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/ProductionSite.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/ProductionSite.java
@@ -15,6 +15,7 @@ public class ProductionSite {
     protected final EnumMap<TankSelector, Tank> tanks = new EnumMap<>(TankSelector.class);;
     protected final EnumMap<TankSelector, Float> inputTemperature
         = new EnumMap<TankSelector, Float>(TankSelector.class);
+    private boolean resetting;
 
     /**
      * Template method to allow subclasses to create objects of subclasses of Tank. The parameters are the same
@@ -47,6 +48,7 @@ public class ProductionSite {
      * Construct a new ProductionSite
      */
     public ProductionSite() {
+        resetting = false;
         initTanks();
     }
 
@@ -125,11 +127,22 @@ public class ProductionSite {
      * a stable state.
      */
     public synchronized void reset() {
+        resetting = true;
         for (TankSelector selector: TankSelector.valuesWithoutMix()) {
             tanks.get(selector).reset();
             inputTemperature.put(selector, selector.getInitialTemperature());
         }
         mixTank.reset();
         inputTemperature.put(TankSelector.MIX, TankSelector.MIX.getInitialTemperature());
+        resetting = false;
+    }
+
+    /**
+     * Returns true, if the ProductionSite is currently in the process of resetting itself,
+     * false otherwise.
+     * @return The value of resetting
+     */
+    public boolean isResetting() {
+        return resetting;
     }
 }

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/behavior/Scenario.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/behavior/Scenario.java
@@ -75,6 +75,7 @@ public class Scenario extends java.util.Observable implements Runnable {
             throw new IllegalStateException("Before running a scenario, the production site needs to be set");
         }
         thread = new Thread(this);
+        thread.setDaemon(true);
         stop = false;
         thread.start();
     }

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/behavior/Scenario.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/behavior/Scenario.java
@@ -28,6 +28,7 @@ public class Scenario extends java.util.Observable implements Runnable {
     public void run() {
         assert (null != productionSite);
         do {
+            productionSite.reset();
             for (ThrowingConsumer<ProductionSite> c : commands) {
                 try {
                     c.accept(productionSite);

--- a/src/osip-simulation-controller/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationController.java
+++ b/src/osip-simulation-controller/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationController.java
@@ -254,6 +254,11 @@ public class SimulationController extends Application {
             }
         });
 
+        currentSimulationView.setResetListener((event) -> {
+           productionSite.reset();
+           controlInterface.update();
+        });
+
         controlInterface.setValveListener((pipe, number) -> {
             pipe.setValveThreshold(number);
             updateServerValues();

--- a/src/osip-simulation-controller/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationController.java
+++ b/src/osip-simulation-controller/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationController.java
@@ -260,8 +260,10 @@ public class SimulationController extends Application {
         });
 
         currentSimulationView.setResetListener((event) -> {
-            currentScenario.cancelScenario();
-            currentSimulationView.scenarioFinished();
+            if (currentScenario != null) {
+                currentScenario.cancelScenario();
+                currentSimulationView.scenarioFinished();
+            }
             productionSite.reset();
             controlInterface.update();
         });

--- a/src/osip-simulation-controller/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationController.java
+++ b/src/osip-simulation-controller/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationController.java
@@ -192,7 +192,7 @@ public class SimulationController extends Application {
             cont.server.setOverheatAlarm(cont.overheatAlarm.isAlarmTriggered());
             cont.server.setUndercoolAlarm(cont.undercoolAlarm.isAlarmTriggered());
 
-            if (cont.tank.getFillLevel() > 1 && !overflow) {
+            if (cont.tank.getFillLevel() > 1 && !overflow && !productionSite.isResetting()) {
                 overflow = true;
                 showOverflow(cont.selector);
             }
@@ -209,13 +209,14 @@ public class SimulationController extends Application {
         mixCont.server.setOverheatAlarm(mixCont.overheatAlarm.isAlarmTriggered());
         mixCont.server.setUndercoolAlarm(mixCont.undercoolAlarm.isAlarmTriggered());
 
-        if (mixCont.tank.getFillLevel() > 1 && !overflow) {
+        if (mixCont.tank.getFillLevel() > 1 && !overflow && !productionSite.isResetting()) {
             overflow = true;
             showOverflow(TankSelector.MIX);
         }
     }
 
     private void showOverflow(TankSelector selector) {
+        controlInterface.setControlsDisabled(true);
         Platform.runLater(() -> currentSimulationView.showOverflow(selector));
         if (currentScenario != null) {
             currentScenario.cancelScenario();
@@ -243,6 +244,7 @@ public class SimulationController extends Application {
         currentSimulationView.setOverflowClosedHandler(actionEvent -> {
             productionSite.reset();
             controlInterface.update();
+            controlInterface.setControlsDisabled(false);
         });
         currentSimulationView.setSettingsButtonHandler(actionEvent -> settingsInterface.show());
         currentSimulationView.setControlButtonHandler(actionEvent -> controlInterface.show());

--- a/src/osip-simulation-controller/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationController.java
+++ b/src/osip-simulation-controller/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationController.java
@@ -228,8 +228,10 @@ public class SimulationController extends Application {
      * @param primaryStage The stage to draw the main window on
      */
     public void start(Stage primaryStage) {
+        controlInterface = new SimulationControlWindow(productionSite);
+
         currentSimulationView = new SimulationMainWindow(productionSite);
-        currentSimulationView.start(primaryStage);
+        currentSimulationView.start(primaryStage, controlInterface);
         setupView();
     }
 
@@ -237,7 +239,6 @@ public class SimulationController extends Application {
         Stage help = new HelpDialog();
         Stage about = new AboutDialog();
         settingsInterface = new SimulationSettingsWindow(settingsWrapper);
-        controlInterface = new SimulationControlWindow(productionSite);
 
         currentSimulationView.setOverflowClosedHandler(actionEvent -> productionSite.reset());
         currentSimulationView.setSettingsButtonHandler(actionEvent -> settingsInterface.show());
@@ -280,6 +281,7 @@ public class SimulationController extends Application {
         currentScenario.setProductionSite(productionSite);
         currentScenario.setScenarioFinishedListener(currentSimulationView::scenarioFinished);
         productionSite.reset();
+        controlInterface.setControlsDisabled(true);
         currentScenario.startScenario();
     }
 

--- a/src/osip-simulation-controller/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationController.java
+++ b/src/osip-simulation-controller/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationController.java
@@ -260,6 +260,8 @@ public class SimulationController extends Application {
         });
 
         currentSimulationView.setResetListener((event) -> {
+            currentScenario.cancelScenario();
+            currentSimulationView.scenarioFinished();
             productionSite.reset();
             controlInterface.update();
         });

--- a/src/osip-simulation-controller/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationController.java
+++ b/src/osip-simulation-controller/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationController.java
@@ -240,7 +240,10 @@ public class SimulationController extends Application {
         Stage about = new AboutDialog();
         settingsInterface = new SimulationSettingsWindow(settingsWrapper);
 
-        currentSimulationView.setOverflowClosedHandler(actionEvent -> productionSite.reset());
+        currentSimulationView.setOverflowClosedHandler(actionEvent -> {
+            productionSite.reset();
+            controlInterface.update();
+        });
         currentSimulationView.setSettingsButtonHandler(actionEvent -> settingsInterface.show());
         currentSimulationView.setControlButtonHandler(actionEvent -> controlInterface.show());
         currentSimulationView.setAboutButtonHandler(actionEvent -> about.show());
@@ -255,8 +258,8 @@ public class SimulationController extends Application {
         });
 
         currentSimulationView.setResetListener((event) -> {
-           productionSite.reset();
-           controlInterface.update();
+            productionSite.reset();
+            controlInterface.update();
         });
 
         controlInterface.setValveListener((pipe, number) -> {

--- a/src/osip-simulation-view-interface/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationControlInterface.java
+++ b/src/osip-simulation-view-interface/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationControlInterface.java
@@ -17,7 +17,11 @@ public interface SimulationControlInterface {
      * Disables or enables all control elements in the SimulationControlWindow to block or allow inputs.
      * @param isDisable true if inputs shall be blocked, false if they shall be enabled
      */
-    public void setControlsDisabled(boolean isDisable);
+    void setControlsDisabled(boolean isDisable);
+    /**
+     * Updates all control elements to use the values of the productionSite
+     */
+    void update();
     /**
      * Sets the listener that is notified of changes to valve thresholds.
      * @param listener The Consumer that gets all changes to valve thresholds.

--- a/src/osip-simulation-view-interface/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationControlInterface.java
+++ b/src/osip-simulation-view-interface/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationControlInterface.java
@@ -14,6 +14,11 @@ import java.util.function.Consumer;
 public interface SimulationControlInterface {
 
     /**
+     * Disables or enables all control elements in the SimulationControlWindow to block or allow inputs.
+     * @param isDisable true if inputs shall be blocked, false if they shall be enabled
+     */
+    public void setControlsDisabled(boolean isDisable);
+    /**
      * Sets the listener that is notified of changes to valve thresholds.
      * @param listener The Consumer that gets all changes to valve thresholds.
      */

--- a/src/osip-simulation-view-interface/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationViewInterface.java
+++ b/src/osip-simulation-view-interface/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationViewInterface.java
@@ -15,7 +15,7 @@ public interface SimulationViewInterface {
      * Draw the simulation view to the stage
      * @param primaryStage The stage that is provided by JavaFx
      */
-    void start(Stage primaryStage);
+    void start(Stage primaryStage, SimulationControlInterface controlWindow);
 
     /**
      * The simulation is replaced by the OverflowOverlay.

--- a/src/osip-simulation-view-interface/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationViewInterface.java
+++ b/src/osip-simulation-view-interface/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationViewInterface.java
@@ -61,6 +61,12 @@ public interface SimulationViewInterface {
     void setScenarioStartListener(Consumer<String> listener);
 
     /**
+     * Sets the listener to reset the simulation
+     * @param listener The listener to be executed
+     */
+    void setResetListener(EventHandler<ActionEvent> listener);
+
+    /**
      * Sets the handler called if the scenario gets stopped by the user.
      * @param listener The handler function.
      */

--- a/src/osip-simulation-view-interface/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationViewInterface.java
+++ b/src/osip-simulation-view-interface/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationViewInterface.java
@@ -14,6 +14,7 @@ public interface SimulationViewInterface {
     /**
      * Draw the simulation view to the stage
      * @param primaryStage The stage that is provided by JavaFx
+     * @param controlWindow The window containing the controls
      */
     void start(Stage primaryStage, SimulationControlInterface controlWindow);
 

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/AbstractTankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/AbstractTankTab.java
@@ -14,13 +14,16 @@ import javafx.scene.control.TextField;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
 
+import java.util.Observable;
+import java.util.Observer;
+
 /**
  * This class contains the controls for a single tank in the simulation.
  *
  * @version 1.0
  * @author Niko Wilhelm
  */
-public abstract class AbstractTankTab extends Tab {
+public abstract class AbstractTankTab extends Tab implements Observer {
 
     protected int row;
 
@@ -42,6 +45,7 @@ public abstract class AbstractTankTab extends Tab {
         pane.setPrefWidth(ViewConstants.CONTROL_WIDTH);
         row = 0;
 
+        tank.addObserver(this);
         createOutFlowSlider(pane, tank);
     }
 
@@ -112,5 +116,11 @@ public abstract class AbstractTankTab extends Tab {
      */
     protected GridPane getGridPane() {
         return pane;
+    }
+
+    public void update(Observable observable, Object o) {
+        AbstractTank tank = (AbstractTank) observable;
+        outFlowSlider.setValue(tank.getOutPipe().getValveThreshold());
+        outFlowValue.setText(String.valueOf(tank.getOutPipe().getValveThreshold()));
     }
 }

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/AbstractTankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/AbstractTankTab.java
@@ -31,6 +31,8 @@ public abstract class AbstractTankTab extends Tab implements Observer {
     private Slider outFlowSlider;
     private TextField outFlowValue;
 
+    private boolean controlsDisabled;
+
     /**
      * Creates a new AbstractTankTab with Sliders to control outFlow and Temperature
      * @param name The name of the AbstractTankTab
@@ -39,6 +41,8 @@ public abstract class AbstractTankTab extends Tab implements Observer {
     public AbstractTankTab(String name, AbstractTank tank) {
         super(name);
         this.setClosable(false);
+
+        controlsDisabled = false;
 
         pane = new GridPane();
         pane.setPrefWidth(ViewConstants.CONTROL_WIDTH);
@@ -102,6 +106,14 @@ public abstract class AbstractTankTab extends Tab implements Observer {
     }
 
     /**
+     * Returns whether or not the control elements are currently disabled.
+     * @return the value of controlsDisabled
+     */
+    protected boolean isControlsDisabled() {
+        return controlsDisabled;
+    }
+
+    /**
      * Gets a reference to the outFlowSlider
      * @return A reference to the outFlowSlider
      */
@@ -117,9 +129,12 @@ public abstract class AbstractTankTab extends Tab implements Observer {
         return pane;
     }
 
+    @Override
     public void update(Observable observable, Object o) {
-        AbstractTank tank = (AbstractTank) observable;
-        outFlowSlider.setValue(tank.getOutPipe().getValveThreshold());
-        outFlowValue.setText(String.valueOf(tank.getOutPipe().getValveThreshold()));
+        if (controlsDisabled) {
+            AbstractTank tank = (AbstractTank) observable;
+            outFlowSlider.setValue(tank.getOutPipe().getValveThreshold());
+            outFlowValue.setText(String.valueOf(tank.getOutPipe().getValveThreshold()));
+        }
     }
 }

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/AbstractTankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/AbstractTankTab.java
@@ -129,12 +129,12 @@ public abstract class AbstractTankTab extends Tab implements Observer {
         return pane;
     }
 
-    @Override
-    public void update(Observable observable, Object o) {
-        if (controlsDisabled) {
-            AbstractTank tank = (AbstractTank) observable;
-            outFlowSlider.setValue(tank.getOutPipe().getValveThreshold());
-            outFlowValue.setText(String.valueOf(tank.getOutPipe().getValveThreshold()));
-        }
+    /**
+     * Updates the AbstractTankTab to show the values from the productionSite
+     * @param tank The tank whose values are taken
+     */
+    public void update(AbstractTank tank) {
+        outFlowSlider.setValue(tank.getOutPipe().getValveThreshold());
+        outFlowValue.setText(String.valueOf(tank.getOutPipe().getValveThreshold()));
     }
 }

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/AbstractTankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/AbstractTankTab.java
@@ -1,7 +1,6 @@
 package edu.kit.pse.osip.simulation.view.control;
 
 import edu.kit.pse.osip.core.model.base.AbstractTank;
-import edu.kit.pse.osip.core.model.base.TankSelector;
 import edu.kit.pse.osip.core.utils.language.Translator;
 import edu.kit.pse.osip.simulation.view.main.ViewConstants;
 import javafx.beans.binding.Bindings;

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/AbstractTankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/AbstractTankTab.java
@@ -1,6 +1,7 @@
 package edu.kit.pse.osip.simulation.view.control;
 
 import edu.kit.pse.osip.core.model.base.AbstractTank;
+import edu.kit.pse.osip.core.model.base.TankSelector;
 import edu.kit.pse.osip.core.utils.language.Translator;
 import edu.kit.pse.osip.simulation.view.main.ViewConstants;
 import javafx.beans.binding.Bindings;
@@ -26,6 +27,7 @@ public abstract class AbstractTankTab extends Tab {
     private GridPane pane;
 
     private Slider outFlowSlider;
+    private TextField outFlowValue;
 
     /**
      * Creates a new AbstractTankTab with Sliders to control outFlow and Temperature
@@ -68,7 +70,7 @@ public abstract class AbstractTankTab extends Tab {
         GridPane.setMargin(outFlowSlider, ViewConstants.CONTROL_PADDING);
 
         //TextField and Label to show the current value and unit
-        TextField outFlowValue = new TextField("" + tank.getOutPipe().getValveThreshold());
+        outFlowValue = new TextField("" + tank.getOutPipe().getValveThreshold());
         outFlowValue.setMaxWidth(ViewConstants.CONTROL_INPUT_WIDTH);
         pane.add(outFlowValue, col++, row);
         GridPane.setMargin(outFlowValue, ViewConstants.CONTROL_PADDING);
@@ -81,6 +83,19 @@ public abstract class AbstractTankTab extends Tab {
         Bindings.bindBidirectional(sp, dp, new ConfinedStringConverter(0d, 100d, sp));
 
         row++;
+    }
+
+    /**
+     * Disables or enables all control elements in the AbstractTankTab to block or allow inputs.
+     * @param isDisable true if inputs shall be blocked, false if they shall be enabled
+     */
+    protected void setControlsDisabled(boolean isDisable) {
+        if (outFlowSlider != null) {
+            outFlowSlider.setDisable(isDisable);
+        }
+        if (outFlowValue != null) {
+            outFlowValue.setDisable(isDisable);
+        }
     }
 
     /**

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/AbstractTankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/AbstractTankTab.java
@@ -12,8 +12,6 @@ import javafx.scene.control.Tab;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
-
-import java.util.Observable;
 import java.util.Observer;
 
 /**
@@ -97,6 +95,7 @@ public abstract class AbstractTankTab extends Tab implements Observer {
      * @param isDisable true if inputs shall be blocked, false if they shall be enabled
      */
     protected void setControlsDisabled(boolean isDisable) {
+        controlsDisabled = isDisable;
         if (outFlowSlider != null) {
             outFlowSlider.setDisable(isDisable);
         }

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/MixTankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/MixTankTab.java
@@ -109,12 +109,20 @@ public class MixTankTab extends AbstractTankTab {
     @Override
     public void update(Observable observable, Object o) {
         if (isControlsDisabled()) {
-            super.update(observable, o);
-
             MixTank tank = (MixTank) observable;
 
-            motorSlider.setValue(tank.getMotor().getRPM());
-            motorValue.setText(String.valueOf(tank.getMotor().getRPM()));
+            update(tank);
         }
+    }
+
+    /**
+     * Updates the MixTankTab to show the values from the productionSite
+     * @param tank The tank whose values are taken
+     */
+    public void update(MixTank tank) {
+        super.update(tank);
+
+        motorSlider.setValue(tank.getMotor().getRPM());
+        motorValue.setText(String.valueOf(tank.getMotor().getRPM()));
     }
 }

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/MixTankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/MixTankTab.java
@@ -110,7 +110,6 @@ public class MixTankTab extends AbstractTankTab {
     public void update(Observable observable, Object o) {
         if (isControlsDisabled()) {
             MixTank tank = (MixTank) observable;
-
             update(tank);
         }
     }

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/MixTankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/MixTankTab.java
@@ -24,6 +24,7 @@ import javafx.util.converter.NumberStringConverter;
 public class MixTankTab extends AbstractTankTab {
 
     private Slider motorSlider;
+    private TextField motorValue;
 
     /**
      * Creates a new TankTab containg the standard controls of the AbstractTankTab as well as a
@@ -67,7 +68,7 @@ public class MixTankTab extends AbstractTankTab {
         GridPane.setMargin(motorSlider, ViewConstants.CONTROL_PADDING);
 
         //TextField and Label to show the current value and unit
-        TextField motorValue = new TextField("" + tank.getMotor().getRPM());
+        motorValue = new TextField("" + tank.getMotor().getRPM());
         motorValue.setMaxWidth(ViewConstants.CONTROL_INPUT_WIDTH);
         pane.add(motorValue, col++, row);
         GridPane.setMargin(motorValue, ViewConstants.CONTROL_PADDING);
@@ -82,6 +83,20 @@ public class MixTankTab extends AbstractTankTab {
         Bindings.bindBidirectional(sp, dp,
             new ConfinedStringConverter(0d, (double) SimulationConstants.MAX_MOTOR_SPEED, sp));
         row++;
+    }
+
+    /**
+     * Disables or enables all control elements in the MixTankTab to block or allow inputs.
+     * @param isDisable true if inputs shall be blocked, false if they shall be enabled
+     */
+    public void setControlsDisabled(boolean isDisable) {
+        if (motorSlider != null) {
+            motorSlider.setDisable(isDisable);
+        }
+        if (motorValue != null) {
+            motorValue.setDisable(isDisable);
+        }
+        super.setControlsDisabled(isDisable);
     }
 
     /**

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/MixTankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/MixTankTab.java
@@ -89,13 +89,13 @@ public class MixTankTab extends AbstractTankTab {
      * @param isDisable true if inputs shall be blocked, false if they shall be enabled
      */
     public void setControlsDisabled(boolean isDisable) {
+        super.setControlsDisabled(isDisable);
         if (motorSlider != null) {
             motorSlider.setDisable(isDisable);
         }
         if (motorValue != null) {
             motorValue.setDisable(isDisable);
         }
-        super.setControlsDisabled(isDisable);
     }
 
     /**
@@ -108,11 +108,13 @@ public class MixTankTab extends AbstractTankTab {
 
     @Override
     public void update(Observable observable, Object o) {
-        super.update(observable, o);
+        if (isControlsDisabled()) {
+            super.update(observable, o);
 
-        MixTank tank = (MixTank) observable;
+            MixTank tank = (MixTank) observable;
 
-        motorSlider.setValue(tank.getMotor().getRPM());
-        motorValue.setText(String.valueOf(tank.getMotor().getRPM()));
+            motorSlider.setValue(tank.getMotor().getRPM());
+            motorValue.setText(String.valueOf(tank.getMotor().getRPM()));
+        }
     }
 }

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/MixTankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/MixTankTab.java
@@ -12,8 +12,6 @@ import javafx.scene.control.Slider;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
-import javafx.util.StringConverter;
-import javafx.util.converter.NumberStringConverter;
 
 import java.util.Observable;
 
@@ -81,7 +79,6 @@ public class MixTankTab extends AbstractTankTab {
 
         StringProperty sp = motorValue.textProperty();
         DoubleProperty dp = motorSlider.valueProperty();
-        StringConverter<Number> converter = new NumberStringConverter();
         Bindings.bindBidirectional(sp, dp,
             new ConfinedStringConverter(0d, (double) SimulationConstants.MAX_MOTOR_SPEED, sp));
         row++;

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/MixTankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/MixTankTab.java
@@ -15,6 +15,8 @@ import javafx.scene.layout.Priority;
 import javafx.util.StringConverter;
 import javafx.util.converter.NumberStringConverter;
 
+import java.util.Observable;
+
 /**
  * This class has controls specific to the tanks in which several inputs are mixed.
  *
@@ -105,5 +107,14 @@ public class MixTankTab extends AbstractTankTab {
      */
     protected Slider getMotorSlider() {
         return motorSlider;
+    }
+
+    @Override
+    public void update(Observable observable, Object o) {
+        MixTank tank = (MixTank) observable;
+
+        motorSlider.setValue(tank.getMotor().getRPM());
+        motorValue.setText(String.valueOf(tank.getMotor().getRPM()));
+        super.update(observable, o);
     }
 }

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/MixTankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/MixTankTab.java
@@ -108,10 +108,11 @@ public class MixTankTab extends AbstractTankTab {
 
     @Override
     public void update(Observable observable, Object o) {
+        super.update(observable, o);
+
         MixTank tank = (MixTank) observable;
 
         motorSlider.setValue(tank.getMotor().getRPM());
         motorValue.setText(String.valueOf(tank.getMotor().getRPM()));
-        super.update(observable, o);
     }
 }

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/SimulationControlWindow.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/SimulationControlWindow.java
@@ -70,10 +70,7 @@ public class SimulationControlWindow extends Stage implements SimulationControlI
         return layout;
     }
 
-    /**
-     * Disables or enables all control elements in the SimulationControlWindow to block or allow inputs.
-     * @param isDisable true if inputs shall be blocked, false if they shall be enabled
-     */
+    @Override
     public void setControlsDisabled(boolean isDisable) {
         for (TankSelector t : TankSelector.values()) {
             AbstractTankTab tab = tankTabs.get(t);

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/SimulationControlWindow.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/SimulationControlWindow.java
@@ -55,7 +55,7 @@ public class SimulationControlWindow extends Stage implements SimulationControlI
         for (TankSelector tankSelector : TankSelector.valuesWithoutMix()) {
             Tank tank = productionSite.getUpperTank(tankSelector);
             TankTab tab = new TankTab(t.getString(
-                    TankSelector.TRANSLATOR_LABEL_PREFIX + tank.getTankSelector().name()), tank);
+                    TankSelector.TRANSLATOR_LABEL_PREFIX + tank.getTankSelector().name()), tank, productionSite);
             tankTabs.put(tankSelector, tab);
             layout.getTabs().add(tab);
         }

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/SimulationControlWindow.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/SimulationControlWindow.java
@@ -78,6 +78,17 @@ public class SimulationControlWindow extends Stage implements SimulationControlI
         }
     }
 
+    @Override
+    public void update() {
+        for (TankSelector t : TankSelector.valuesWithoutMix()) {
+            TankTab tab = (TankTab) tankTabs.get(t);
+            tab.update(productionSite.getUpperTank(t));
+        }
+
+        MixTankTab mixTab = (MixTankTab) tankTabs.get(TankSelector.MIX);
+        mixTab.update(productionSite.getMixTank());
+    }
+
     /**
      * Sets the listener that is notified of changes to valve thresholds.
      * @param listener The Consumer that gets all changes to valve thresholds.

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/SimulationControlWindow.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/SimulationControlWindow.java
@@ -71,6 +71,17 @@ public class SimulationControlWindow extends Stage implements SimulationControlI
     }
 
     /**
+     * Disables or enables all control elements in the SimulationControlWindow to block or allow inputs.
+     * @param isDisable true if inputs shall be blocked, false if they shall be enabled
+     */
+    public void setControlsDisabled(boolean isDisable) {
+        for (TankSelector t : TankSelector.values()) {
+            AbstractTankTab tab = tankTabs.get(t);
+            tab.setControlsDisabled(isDisable);
+        }
+    }
+
+    /**
      * Sets the listener that is notified of changes to valve thresholds.
      * @param listener The Consumer that gets all changes to valve thresholds.
      */

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/TankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/TankTab.java
@@ -2,7 +2,6 @@ package edu.kit.pse.osip.simulation.view.control;
 
 import edu.kit.pse.osip.core.SimulationConstants;
 import edu.kit.pse.osip.core.model.base.AbstractTank;
-import edu.kit.pse.osip.core.model.base.MixTank;
 import edu.kit.pse.osip.core.model.base.Tank;
 import edu.kit.pse.osip.core.utils.language.Translator;
 import edu.kit.pse.osip.simulation.view.main.ViewConstants;
@@ -14,8 +13,6 @@ import javafx.scene.control.Slider;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
-import javafx.util.StringConverter;
-import javafx.util.converter.NumberStringConverter;
 
 import java.util.Observable;
 
@@ -85,7 +82,6 @@ public class TankTab extends AbstractTankTab {
 
         StringProperty sp = inFlowValue.textProperty();
         DoubleProperty dp = inFlowSlider.valueProperty();
-        StringConverter<Number> converter = new NumberStringConverter();
         Bindings.bindBidirectional(sp, dp, new ConfinedStringConverter(0d, 100d, sp));
         row++;
     }
@@ -129,7 +125,6 @@ public class TankTab extends AbstractTankTab {
 
         StringProperty sp = temperatureValue.textProperty();
         DoubleProperty dp = temperatureSlider.valueProperty();
-        StringConverter<Number> converter = new NumberStringConverter();
         Bindings.bindBidirectional(sp, dp, new ConfinedStringConverter((double) min,
             (double) SimulationConstants.MAX_TEMPERATURE - SimulationConstants.CELCIUS_OFFSET, sp));
         row++;

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/TankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/TankTab.java
@@ -40,6 +40,7 @@ public class TankTab extends AbstractTankTab {
      * slider to control inFlow.
      * @param name The name of the AbstractTankTab
      * @param tank The AbstractTank which is controlled through the AbstractTankTab.
+     * @param site The ProductionSite in which tank resides
      */
     public TankTab(String name, Tank tank, ProductionSite site) {
         super(name, tank);
@@ -143,6 +144,7 @@ public class TankTab extends AbstractTankTab {
      * @param isDisable true if inputs shall be blocked, false if they shall be enabled
      */
     public void setControlsDisabled(boolean isDisable) {
+        super.setControlsDisabled(isDisable);
         if (inFlowSlider != null) {
             inFlowSlider.setDisable(isDisable);
         }
@@ -155,7 +157,6 @@ public class TankTab extends AbstractTankTab {
         if (temperatureValue != null) {
             temperatureValue.setDisable(isDisable);
         }
-        super.setControlsDisabled(isDisable);
     }
 
     /**
@@ -176,15 +177,17 @@ public class TankTab extends AbstractTankTab {
 
     @Override
     public void update(Observable observable, Object o) {
-        super.update(observable, o);
+        if (isControlsDisabled()) {
+            super.update(observable, o);
 
-        Tank tank = (Tank) observable;
+            Tank tank = (Tank) observable;
 
-        inFlowSlider.setValue(tank.getInPipe().getValveThreshold());
-        inFlowValue.setText(String.valueOf(tank.getInPipe().getValveThreshold()));
+            inFlowSlider.setValue(tank.getInPipe().getValveThreshold());
+            inFlowValue.setText(String.valueOf(tank.getInPipe().getValveThreshold()));
 
-        temperatureSlider.setValue(site.getInputTemperature(selector));
-        temperatureValue.setText(String.valueOf(site.getInputTemperature(selector)));
+            temperatureSlider.setValue(site.getInputTemperature(selector));
+            temperatureValue.setText(String.valueOf(site.getInputTemperature(selector)));
+        }
     }
 
 }

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/TankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/TankTab.java
@@ -25,8 +25,10 @@ import javafx.util.converter.NumberStringConverter;
 public class TankTab extends AbstractTankTab {
 
     private Slider inFlowSlider;
+    private TextField inFlowValue;
 
     private Slider temperatureSlider;
+    private TextField temperatureValue;
 
     /**
      * Creates a new TankTab containing the standard controls of the AbstractTankTab as well as a
@@ -70,7 +72,7 @@ public class TankTab extends AbstractTankTab {
         GridPane.setMargin(inFlowSlider, ViewConstants.CONTROL_PADDING);
 
         //TextField and label to show the current value and unit
-        TextField inFlowValue = new TextField("" + tank.getOutPipe().getValveThreshold());
+        inFlowValue = new TextField("" + tank.getOutPipe().getValveThreshold());
         inFlowValue.setMaxWidth(ViewConstants.CONTROL_INPUT_WIDTH);
         pane.add(inFlowValue, col++, row);
         GridPane.setMargin(inFlowValue, ViewConstants.CONTROL_PADDING);
@@ -114,7 +116,7 @@ public class TankTab extends AbstractTankTab {
         GridPane.setMargin(temperatureSlider, ViewConstants.CONTROL_PADDING);
 
         //Labels to show the current value and unit
-        TextField temperatureValue = new TextField("" + tank.getLiquid().getTemperature());
+        temperatureValue = new TextField("" + tank.getLiquid().getTemperature());
         temperatureValue.setMaxWidth(ViewConstants.CONTROL_INPUT_WIDTH);
         pane.add(temperatureValue, col++, row);
         GridPane.setMargin(temperatureValue, ViewConstants.CONTROL_PADDING);
@@ -128,6 +130,26 @@ public class TankTab extends AbstractTankTab {
         Bindings.bindBidirectional(sp, dp, new ConfinedStringConverter((double) min,
             (double) SimulationConstants.MAX_TEMPERATURE - SimulationConstants.CELCIUS_OFFSET, sp));
         row++;
+    }
+
+    /**
+     * Disables or enables all control elements in the TankTab to block or allow inputs.
+     * @param isDisable true if inputs shall be blocked, false if they shall be enabled
+     */
+    public void setControlsDisabled(boolean isDisable) {
+        if (inFlowSlider != null) {
+            inFlowSlider.setDisable(isDisable);
+        }
+        if (inFlowValue != null) {
+            inFlowValue.setDisable(isDisable);
+        }
+        if (temperatureSlider != null) {
+            temperatureSlider.setDisable(isDisable);
+        }
+        if (temperatureValue != null) {
+            temperatureValue.setDisable(isDisable);
+        }
+        super.setControlsDisabled(isDisable);
     }
 
     /**

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/TankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/TankTab.java
@@ -178,16 +178,25 @@ public class TankTab extends AbstractTankTab {
     @Override
     public void update(Observable observable, Object o) {
         if (isControlsDisabled()) {
-            super.update(observable, o);
 
             Tank tank = (Tank) observable;
-
-            inFlowSlider.setValue(tank.getInPipe().getValveThreshold());
-            inFlowValue.setText(String.valueOf(tank.getInPipe().getValveThreshold()));
-
-            temperatureSlider.setValue(site.getInputTemperature(selector));
-            temperatureValue.setText(String.valueOf(site.getInputTemperature(selector)));
+            update(tank);
         }
+    }
+
+    /**
+     * Updates the TankTab to show the values from the productionSite
+     * @param tank The tank whose values are taken
+     */
+    public void update(Tank tank) {
+        super.update(tank);
+
+        inFlowSlider.setValue(tank.getInPipe().getValveThreshold());
+        inFlowValue.setText(String.valueOf(tank.getInPipe().getValveThreshold()));
+
+        temperatureSlider.setValue(site.getInputTemperature(selector) - SimulationConstants.CELCIUS_OFFSET);
+        temperatureValue.setText(String.valueOf(
+                site.getInputTemperature(selector) - SimulationConstants.CELCIUS_OFFSET));
     }
 
 }

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/TankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/TankTab.java
@@ -2,6 +2,7 @@ package edu.kit.pse.osip.simulation.view.control;
 
 import edu.kit.pse.osip.core.SimulationConstants;
 import edu.kit.pse.osip.core.model.base.AbstractTank;
+import edu.kit.pse.osip.core.model.base.MixTank;
 import edu.kit.pse.osip.core.model.base.Tank;
 import edu.kit.pse.osip.core.utils.language.Translator;
 import edu.kit.pse.osip.simulation.view.main.ViewConstants;
@@ -15,6 +16,8 @@ import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
 import javafx.util.StringConverter;
 import javafx.util.converter.NumberStringConverter;
+
+import java.util.Observable;
 
 /**
  * This class has controls specific to the input tanks.
@@ -166,6 +169,18 @@ public class TankTab extends AbstractTankTab {
      */
     protected Slider getTemperatureSlider() {
         return temperatureSlider;
+    }
+
+    @Override
+    public void update(Observable observable, Object o) {
+        Tank tank = (Tank) observable;
+
+        inFlowSlider.setValue(tank.getInPipe().getValveThreshold());
+        inFlowValue.setText(String.valueOf(tank.getInPipe().getValveThreshold()));
+
+        temperatureSlider.setValue(tank.getLiquid().getTemperature());
+        temperatureValue.setText(String.valueOf(tank.getLiquid().getTemperature()));
+        super.update(observable, o);
     }
 
 }

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/TankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/TankTab.java
@@ -2,7 +2,9 @@ package edu.kit.pse.osip.simulation.view.control;
 
 import edu.kit.pse.osip.core.SimulationConstants;
 import edu.kit.pse.osip.core.model.base.AbstractTank;
+import edu.kit.pse.osip.core.model.base.ProductionSite;
 import edu.kit.pse.osip.core.model.base.Tank;
+import edu.kit.pse.osip.core.model.base.TankSelector;
 import edu.kit.pse.osip.core.utils.language.Translator;
 import edu.kit.pse.osip.simulation.view.main.ViewConstants;
 import javafx.beans.binding.Bindings;
@@ -30,14 +32,20 @@ public class TankTab extends AbstractTankTab {
     private Slider temperatureSlider;
     private TextField temperatureValue;
 
+    private TankSelector selector;
+    private ProductionSite site;
+
     /**
      * Creates a new TankTab containing the standard controls of the AbstractTankTab as well as a
      * slider to control inFlow.
      * @param name The name of the AbstractTankTab
      * @param tank The AbstractTank which is controlled through the AbstractTankTab.
      */
-    public TankTab(String name, Tank tank) {
+    public TankTab(String name, Tank tank, ProductionSite site) {
         super(name, tank);
+
+        this.selector = tank.getTankSelector();
+        this.site = site;
 
         GridPane pane = getGridPane();
 
@@ -168,14 +176,15 @@ public class TankTab extends AbstractTankTab {
 
     @Override
     public void update(Observable observable, Object o) {
+        super.update(observable, o);
+
         Tank tank = (Tank) observable;
 
         inFlowSlider.setValue(tank.getInPipe().getValveThreshold());
         inFlowValue.setText(String.valueOf(tank.getInPipe().getValveThreshold()));
 
-        temperatureSlider.setValue(tank.getLiquid().getTemperature());
-        temperatureValue.setText(String.valueOf(tank.getLiquid().getTemperature()));
-        super.update(observable, o);
+        temperatureSlider.setValue(site.getInputTemperature(selector));
+        temperatureValue.setText(String.valueOf(site.getInputTemperature(selector)));
     }
 
 }

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/MotorDrawer.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/MotorDrawer.java
@@ -41,7 +41,7 @@ public class MotorDrawer extends RotatingControlDrawer {
         setSpeed(motor.getRPM());
 
         // Convert the minutes to degrees to be turned in total
-        double degrees = time * getSpeed() * 360;
+        double degrees = time * (getSpeed() * ViewConstants.MOTOR_SPEED_FACTOR) * 360;
 
         Canvas canvas = context.getCanvas();
         double totalWidth = canvas.getWidth();

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMainWindow.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMainWindow.java
@@ -7,7 +7,6 @@ import edu.kit.pse.osip.core.model.base.TankSelector;
 import edu.kit.pse.osip.core.utils.language.Translator;
 import edu.kit.pse.osip.simulation.controller.SimulationControlInterface;
 import edu.kit.pse.osip.simulation.controller.SimulationViewInterface;
-import edu.kit.pse.osip.simulation.view.control.SimulationControlWindow;
 import edu.kit.pse.osip.simulation.view.dialogs.OverflowDialog;
 import java.util.function.Consumer;
 import javafx.animation.AnimationTimer;
@@ -287,6 +286,11 @@ public class SimulationMainWindow implements SimulationViewInterface {
      */
     public final void setHelpButtonHandler(EventHandler<ActionEvent> helpButtonHandler) {
         menu.setHelpButtonHandler(helpButtonHandler);
+    }
+
+    @Override
+    public void setResetListener(EventHandler<ActionEvent> listener) {
+        menu.setResetButtonHandler(listener);
     }
 
 

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMainWindow.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMainWindow.java
@@ -227,6 +227,14 @@ public class SimulationMainWindow implements SimulationViewInterface {
         menu.setControlButtonHandler(controlButtonHandler);
     }
 
+    /**
+     * Sets the handler for pressing the reset entry in the menu
+     * @param resetButtonHandler The handler to execute
+     */
+    public final void setResetButtonHandler(EventHandler<ActionEvent> resetButtonHandler) {
+        menu.setResetButtonHandler(resetButtonHandler);
+    }
+
     @Override
     public void setScenarioStartListener(Consumer<String> listener) {
         menu.setScenarioStartListener(listener);

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMainWindow.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMainWindow.java
@@ -130,6 +130,7 @@ public class SimulationMainWindow implements SimulationViewInterface {
     /**
      * The stage that is provided by JavaFx
      * @param primaryStage The stage to draw the window on
+     * @param controlWindow The window containing the controls
      */
     public final void start(Stage primaryStage, SimulationControlInterface controlWindow) {
         primaryStage.setTitle(Translator.getInstance().getString("simulation.title"));

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMainWindow.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMainWindow.java
@@ -5,7 +5,9 @@ import edu.kit.pse.osip.core.model.base.ProductionSite;
 import edu.kit.pse.osip.core.model.base.Tank;
 import edu.kit.pse.osip.core.model.base.TankSelector;
 import edu.kit.pse.osip.core.utils.language.Translator;
+import edu.kit.pse.osip.simulation.controller.SimulationControlInterface;
 import edu.kit.pse.osip.simulation.controller.SimulationViewInterface;
+import edu.kit.pse.osip.simulation.view.control.SimulationControlWindow;
 import edu.kit.pse.osip.simulation.view.dialogs.OverflowDialog;
 import java.util.function.Consumer;
 import javafx.animation.AnimationTimer;
@@ -130,7 +132,7 @@ public class SimulationMainWindow implements SimulationViewInterface {
      * The stage that is provided by JavaFx
      * @param primaryStage The stage to draw the window on
      */
-    public final void start(Stage primaryStage) {
+    public final void start(Stage primaryStage, SimulationControlInterface controlWindow) {
         primaryStage.setTitle(Translator.getInstance().getString("simulation.title"));
         primaryStage.getIcons().add(new Image("/icon.png"));
 
@@ -144,17 +146,17 @@ public class SimulationMainWindow implements SimulationViewInterface {
 
         setResizeListeners(primaryStage);
 
-        makeLayout(primaryStage);
+        makeLayout(primaryStage, controlWindow);
 
         primaryStage.show();
     }
 
-    private void makeLayout(Stage primaryStage) {
+    private void makeLayout(Stage primaryStage, SimulationControlInterface controlWindow) {
         BorderPane mainPane = new BorderPane();
 
         mainPane.setStyle("-fx-font-size:" + ViewConstants.FONT_SIZE + "px;");
 
-        menu = new SimulationMenu();
+        menu = new SimulationMenu(controlWindow);
         mainPane.setTop(menu);
 
         canvas = setCanvas(primaryStage);

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMainWindow.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMainWindow.java
@@ -229,14 +229,6 @@ public class SimulationMainWindow implements SimulationViewInterface {
         menu.setControlButtonHandler(controlButtonHandler);
     }
 
-    /**
-     * Sets the handler for pressing the reset entry in the menu
-     * @param resetButtonHandler The handler to execute
-     */
-    public final void setResetButtonHandler(EventHandler<ActionEvent> resetButtonHandler) {
-        menu.setResetButtonHandler(resetButtonHandler);
-    }
-
     @Override
     public void setScenarioStartListener(Consumer<String> listener) {
         menu.setScenarioStartListener(listener);

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMenu.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMenu.java
@@ -3,6 +3,8 @@ package edu.kit.pse.osip.simulation.view.main;
 import edu.kit.pse.osip.core.utils.language.Translator;
 import java.io.File;
 import java.util.function.Consumer;
+
+import edu.kit.pse.osip.simulation.controller.SimulationControlInterface;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.scene.control.Menu;
@@ -54,12 +56,16 @@ public class SimulationMenu extends MenuBar {
     private MenuItem menuItemStartScenario;
     private MenuItem menuItemStopScenario;
 
+    private SimulationControlInterface controlWindow;
+
     /**
      * Creates and initializes the menu for the simulation view.
      */
-    protected SimulationMenu() {
+    protected SimulationMenu(SimulationControlInterface controlWindow) {
         this.setStyle("-fx-font-size:" + ViewConstants.FONT_SIZE + "px;");
         Translator trans = Translator.getInstance();
+
+        this.controlWindow = controlWindow;
 
         menuButtonFile = new Menu(trans.getString("simulation.view.menu.file"));
         menuItemSettings = new MenuItem(trans.getString("simulation.view.menu.file.settings"));
@@ -160,5 +166,6 @@ public class SimulationMenu extends MenuBar {
     public void setScenarioFinished() {
         menuItemStartScenario.setDisable(false);
         menuItemStopScenario.setDisable(true);
+        controlWindow.setControlsDisabled(false);
     }
 }

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMenu.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMenu.java
@@ -60,6 +60,7 @@ public class SimulationMenu extends MenuBar {
 
     /**
      * Creates and initializes the menu for the simulation view.
+     * @param controlWindow The window containing the controls
      */
     protected SimulationMenu(SimulationControlInterface controlWindow) {
         this.setStyle("-fx-font-size:" + ViewConstants.FONT_SIZE + "px;");
@@ -79,8 +80,7 @@ public class SimulationMenu extends MenuBar {
         menuOther = new Menu(trans.getString("simulation.view.menu.other"));
         menuItemHelp = new MenuItem(trans.getString("simulation.view.menu.other.help"));
         menuItemAbout = new MenuItem(trans.getString("simulation.view.menu.other.about"));
-        menuOther.getItems().add(menuItemHelp);
-        menuOther.getItems().add(menuItemAbout);
+        menuOther.getItems().addAll(menuItemHelp, menuItemAbout);
 
         menuScenario = new Menu(trans.getString("simulation.view.menu.scenario"));
         menuItemStartScenario = new MenuItem(trans.getString("simulation.view.menu.scenario.start"));

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMenu.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMenu.java
@@ -30,6 +30,7 @@ public class SimulationMenu extends MenuBar {
      */
     private Menu menuButtonFile;
     private MenuItem menuItemSettings;
+    private MenuItem menuItemReset;
 
     /**
      * Menu containing all buttons for help.
@@ -62,7 +63,8 @@ public class SimulationMenu extends MenuBar {
 
         menuButtonFile = new Menu(trans.getString("simulation.view.menu.file"));
         menuItemSettings = new MenuItem(trans.getString("simulation.view.menu.file.settings"));
-        menuButtonFile.getItems().add(menuItemSettings);
+        menuItemReset = new MenuItem(trans.getString("simulation.view.menu.file.reset"));
+        menuButtonFile.getItems().addAll(menuItemSettings, menuItemReset);
 
         menuButtonView = new Menu(trans.getString("simulation.view.menu.view"));
         menuItemControl = new MenuItem(trans.getString("simulation.view.menu.view.control"));
@@ -97,6 +99,14 @@ public class SimulationMenu extends MenuBar {
      */
     public final void setSettingsButtonHandler(EventHandler<ActionEvent> settingsButtonHandler) {
         menuItemSettings.setOnAction(settingsButtonHandler);
+    }
+
+    /**
+     * Sets the handler for pressing the reset entry in the menu
+     * @param resetButtonHandler The handler to execute
+     */
+    public final void setResetButtonHandler(EventHandler<ActionEvent> resetButtonHandler) {
+        menuItemReset.setOnAction(resetButtonHandler);
     }
 
     /**

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/ViewConstants.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/ViewConstants.java
@@ -1,5 +1,6 @@
 package edu.kit.pse.osip.simulation.view.main;
 
+import edu.kit.pse.osip.core.SimulationConstants;
 import javafx.geometry.Insets;
 import javafx.stage.Screen;
 
@@ -88,6 +89,12 @@ public final class ViewConstants {
      * of the box containing a tank and its sensors.
      */
     protected static final double MOTOR_LINE_WIDTH = 5;
+
+    /**
+     * The factor of the simulation motor speed that is shown in the simulation gui. It scales the
+     * shown rpm to 0 - 50, as anything above that is not shown in an aesthetically pleasing way.
+     */
+    protected static final double MOTOR_SPEED_FACTOR = 1.0 / ((double) SimulationConstants.MAX_MOTOR_SPEED / 50);
 
     /**
      * The width of the TemperatureSensor relative to the height of the box containing a tank and its

--- a/src/osip-simulation-view/src/main/resources/Bundle.properties
+++ b/src/osip-simulation-view/src/main/resources/Bundle.properties
@@ -21,6 +21,7 @@ simulation.overflowdialog.reset=Reset Simulation
 simulation.title=OSIP - Simulation
 simulation.view.menu.file=File
 simulation.view.menu.file.settings=Settings
+simulation.view.menu.file.reset=Reset
 simulation.view.menu.view=View
 simulation.view.menu.view.control=Control
 simulation.view.menu.other=?


### PR DESCRIPTION
Die Steuerungselemente der Simulation koennen jetzt deaktiviert werden.
Die Steuerungselemente observen ihre jeweiligen Tanks, um Aenderungen zu uebernehmen.
Es gibt einen reset-button im Menue.