### PR TITLE
A different approach to the slider update problem

### DIFF
--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/ProductionSite.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/ProductionSite.java
@@ -16,7 +16,6 @@ public class ProductionSite extends Observable {
     protected final EnumMap<TankSelector, Tank> tanks = new EnumMap<>(TankSelector.class);;
     protected final EnumMap<TankSelector, Float> inputTemperature
         = new EnumMap<TankSelector, Float>(TankSelector.class);
-    private boolean resetting;
 
     /**
      * Template method to allow subclasses to create objects of subclasses of Tank. The parameters are the same
@@ -49,7 +48,6 @@ public class ProductionSite extends Observable {
      * Construct a new ProductionSite
      */
     public ProductionSite() {
-        resetting = false;
         initTanks();
     }
 
@@ -130,25 +128,14 @@ public class ProductionSite extends Observable {
      * a stable state.
      */
     public synchronized void reset() {
-        resetting = true;
         for (TankSelector selector: TankSelector.valuesWithoutMix()) {
             tanks.get(selector).reset();
             inputTemperature.put(selector, selector.getInitialTemperature());
         }
         mixTank.reset();
         inputTemperature.put(TankSelector.MIX, TankSelector.MIX.getInitialTemperature());
-        resetting = false;
         setChanged();
         notifyObservers();
 
-    }
-
-    /**
-     * Returns true, if the ProductionSite is currently in the process of resetting itself,
-     * false otherwise.
-     * @return The value of resetting
-     */
-    public boolean isResetting() {
-        return resetting;
     }
 }

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/ProductionSite.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/ProductionSite.java
@@ -2,6 +2,7 @@ package edu.kit.pse.osip.core.model.base;
 
 import edu.kit.pse.osip.core.SimulationConstants;
 import java.util.EnumMap;
+import java.util.Observable;
 
 /**
  * Group all tanks in the production site together. This is the entrance point of the model, because you can get every
@@ -10,7 +11,7 @@ import java.util.EnumMap;
  * @version
  * 1.0
  */
-public class ProductionSite {
+public class ProductionSite extends Observable {
     protected MixTank mixTank;
     protected final EnumMap<TankSelector, Tank> tanks = new EnumMap<>(TankSelector.class);;
     protected final EnumMap<TankSelector, Float> inputTemperature
@@ -76,6 +77,8 @@ public class ProductionSite {
         }
 
         inputTemperature.put(tank, temperature);
+        setChanged();
+        notifyObservers();
     }
 
     private void initTanks() {
@@ -135,6 +138,9 @@ public class ProductionSite {
         mixTank.reset();
         inputTemperature.put(TankSelector.MIX, TankSelector.MIX.getInitialTemperature());
         resetting = false;
+        setChanged();
+        notifyObservers();
+
     }
 
     /**

--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/behavior/Scenario.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/behavior/Scenario.java
@@ -88,9 +88,6 @@ public class Scenario extends java.util.Observable implements Runnable {
         if (null == thread) {
             throw new IllegalStateException("Scenario has not been started yet");
         }
-        if (finishedListener != null) {
-            finishedListener.run();
-        }
     }
 
     /**

--- a/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/ProductionSiteTest.java
+++ b/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/base/ProductionSiteTest.java
@@ -4,6 +4,10 @@ import edu.kit.pse.osip.core.SimulationConstants;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.util.Observable;
+import java.util.Observer;
+
+import static junit.framework.TestCase.assertFalse;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -14,8 +18,9 @@ import static org.junit.Assert.assertTrue;
  * @author David Kahles
  * @version 1.0
  */
-public class ProductionSiteTest {
+public class ProductionSiteTest implements Observer {
     ProductionSite prodSite;
+    boolean updated;
 
     /**
      * Initialize prodSite
@@ -23,6 +28,7 @@ public class ProductionSiteTest {
     @Before
     public void init() {
         prodSite = new ProductionSite();
+        updated = false;
     }
 
     /**
@@ -158,8 +164,14 @@ public class ProductionSiteTest {
      */
     @Test
     public void testInputTemperature() {
+        prodSite.addObserver(this);
+        assertFalse(updated);
         prodSite.setInputTemperature(TankSelector.MIX, SimulationConstants.MIN_TEMPERATURE);
         assertEquals(SimulationConstants.MIN_TEMPERATURE, prodSite.getInputTemperature(TankSelector.MIX), 0.0001);
+        assertTrue(updated);
+        updated = false;
+        prodSite.reset();
+        assertTrue(updated);
     }
 
     /**
@@ -176,5 +188,10 @@ public class ProductionSiteTest {
     @Test(expected = IllegalArgumentException.class)
     public void testTooHighInputTemperature() {
         prodSite.setInputTemperature(TankSelector.MIX, SimulationConstants.MAX_TEMPERATURE + 1);
+    }
+
+    @Override
+    public void update(Observable o, Object arg) {
+        updated = true;
     }
 }

--- a/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/behavior/ScenarioTest.java
+++ b/src/osip-model/src/test/java/edu/kit/pse/osip/core/model/behavior/ScenarioTest.java
@@ -123,12 +123,10 @@ public class ScenarioTest {
      */
     @Test
     public void testStop() {
-        CompletableFuture<Boolean> finished = new CompletableFuture<>();
         scenario.appendRunnable(productionSite -> counter.incrementAndGet());
         scenario.addPause(300);
         scenario.appendRunnable(productionSite -> counter.incrementAndGet());
         scenario.setProductionSite(fakeSite);
-        scenario.setScenarioFinishedListener(() -> finished.complete(true));
         scenario.startScenario();
         try {
             sleep(100);
@@ -144,13 +142,8 @@ public class ScenarioTest {
         } catch (InterruptedException ex) {
             System.err.println("Sleep failed in ScenarioTest: " + ex.getMessage());
         }
-        try {
-            assertEquals(1, counter.get());
-            assertFalse(scenario.isRunning());
-            assertTrue(finished.get());
-        } catch (InterruptedException | ExecutionException ex) {
-            System.err.println("CompletableFuture.get() failed in ScenarioTest: " + ex.getMessage());
-        }
+        assertEquals(1, counter.get());
+        assertFalse(scenario.isRunning());
     }
 
     /**

--- a/src/osip-simulation-controller/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationController.java
+++ b/src/osip-simulation-controller/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationController.java
@@ -259,8 +259,8 @@ public class SimulationController extends Application {
                 currentScenario.cancelScenario();
                 currentSimulationView.scenarioFinished();
             }
+            controlInterface.setControlsDisabled(true);
             productionSite.reset();
-            controlInterface.update();
             controlInterface.setControlsDisabled(false);
         });
 

--- a/src/osip-simulation-controller/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationController.java
+++ b/src/osip-simulation-controller/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationController.java
@@ -252,6 +252,7 @@ public class SimulationController extends Application {
             if (currentScenario != null) {
                 currentScenario.cancelScenario();
                 currentSimulationView.scenarioFinished();
+                controlInterface.setControlsDisabled(false);
             }
         });
 
@@ -259,6 +260,7 @@ public class SimulationController extends Application {
             if (currentScenario != null) {
                 currentScenario.cancelScenario();
                 currentSimulationView.scenarioFinished();
+                controlInterface.setControlsDisabled(false);
             }
             resetInProgress = true;
             productionSite.reset();
@@ -291,7 +293,10 @@ public class SimulationController extends Application {
             return;
         }
         currentScenario.setProductionSite(productionSite);
-        currentScenario.setScenarioFinishedListener(currentSimulationView::scenarioFinished);
+        currentScenario.setScenarioFinishedListener(() -> {
+            currentSimulationView.scenarioFinished();
+            controlInterface.setControlsDisabled(false);
+        });
         controlInterface.setControlsDisabled(true);
         resetInProgress = true;
         productionSite.reset();

--- a/src/osip-simulation-controller/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationController.java
+++ b/src/osip-simulation-controller/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationController.java
@@ -51,6 +51,7 @@ public class SimulationController extends Application {
     private ServerSettingsWrapper settingsWrapper;
     private boolean overflow = false;
     private Timer stepTimer = new Timer(true);
+    private boolean resetInProgress = false;
 
     private static final float FILL_ALARM_LOWER_THRESHOLD = 0.05f;
     private static final float FILL_ALARM_UPPER_THRESHOLD = 0.95f;
@@ -192,7 +193,7 @@ public class SimulationController extends Application {
             cont.server.setOverheatAlarm(cont.overheatAlarm.isAlarmTriggered());
             cont.server.setUndercoolAlarm(cont.undercoolAlarm.isAlarmTriggered());
 
-            if (cont.tank.getFillLevel() > 1 && !overflow && !productionSite.isResetting()) {
+            if (cont.tank.getFillLevel() > 1 && !overflow && !resetInProgress) {
                 overflow = true;
                 showOverflow(cont.selector);
             }
@@ -209,7 +210,7 @@ public class SimulationController extends Application {
         mixCont.server.setOverheatAlarm(mixCont.overheatAlarm.isAlarmTriggered());
         mixCont.server.setUndercoolAlarm(mixCont.undercoolAlarm.isAlarmTriggered());
 
-        if (mixCont.tank.getFillLevel() > 1 && !overflow && !productionSite.isResetting()) {
+        if (mixCont.tank.getFillLevel() > 1 && !overflow && !resetInProgress) {
             overflow = true;
             showOverflow(TankSelector.MIX);
         }
@@ -259,8 +260,9 @@ public class SimulationController extends Application {
                 currentScenario.cancelScenario();
                 currentSimulationView.scenarioFinished();
             }
-            controlInterface.setControlsDisabled(true);
+            resetInProgress = true;
             productionSite.reset();
+            resetInProgress = false;
             controlInterface.setControlsDisabled(false);
         });
 
@@ -290,8 +292,10 @@ public class SimulationController extends Application {
         }
         currentScenario.setProductionSite(productionSite);
         currentScenario.setScenarioFinishedListener(currentSimulationView::scenarioFinished);
-        productionSite.reset();
         controlInterface.setControlsDisabled(true);
+        resetInProgress = true;
+        productionSite.reset();
+        resetInProgress = false;
         currentScenario.startScenario();
     }
 

--- a/src/osip-simulation-controller/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationController.java
+++ b/src/osip-simulation-controller/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationController.java
@@ -241,11 +241,6 @@ public class SimulationController extends Application {
         Stage about = new AboutDialog();
         settingsInterface = new SimulationSettingsWindow(settingsWrapper);
 
-        currentSimulationView.setOverflowClosedHandler(actionEvent -> {
-            productionSite.reset();
-            controlInterface.update();
-            controlInterface.setControlsDisabled(false);
-        });
         currentSimulationView.setSettingsButtonHandler(actionEvent -> settingsInterface.show());
         currentSimulationView.setControlButtonHandler(actionEvent -> controlInterface.show());
         currentSimulationView.setAboutButtonHandler(actionEvent -> about.show());
@@ -266,6 +261,7 @@ public class SimulationController extends Application {
             }
             productionSite.reset();
             controlInterface.update();
+            controlInterface.setControlsDisabled(false);
         });
 
         controlInterface.setValveListener((pipe, number) -> {

--- a/src/osip-simulation-view-interface/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationControlInterface.java
+++ b/src/osip-simulation-view-interface/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationControlInterface.java
@@ -19,10 +19,6 @@ public interface SimulationControlInterface {
      */
     void setControlsDisabled(boolean isDisable);
     /**
-     * Updates all control elements to use the values of the productionSite
-     */
-    void update();
-    /**
      * Sets the listener that is notified of changes to valve thresholds.
      * @param listener The Consumer that gets all changes to valve thresholds.
      */

--- a/src/osip-simulation-view-interface/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationViewInterface.java
+++ b/src/osip-simulation-view-interface/src/main/java/edu/kit/pse/osip/simulation/controller/SimulationViewInterface.java
@@ -28,12 +28,6 @@ public interface SimulationViewInterface {
      * Set a handler which gets called if the users closes the overflow dialog
      * @param handler The handler to set.
      */
-    void setOverflowClosedHandler(EventHandler<ActionEvent> handler);
-
-    /**
-     * Set a handler which gets called if the users closes the overflow dialog
-     * @param handler The handler to set.
-     */
     void setHelpButtonHandler(EventHandler<ActionEvent> handler);
 
     /**

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/AbstractTankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/AbstractTankTab.java
@@ -10,8 +10,11 @@ import javafx.scene.control.Label;
 import javafx.scene.control.Slider;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TextField;
+import javafx.scene.control.TextFormatter;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
+import javafx.util.converter.IntegerStringConverter;
+
 import java.util.Observer;
 
 /**
@@ -68,14 +71,12 @@ public abstract class AbstractTankTab extends Tab implements Observer {
         outFlowSlider.setPrefWidth(ViewConstants.CONTROL_SLIDER_WIDTH);
         GridPane.setHgrow(outFlowSlider, Priority.ALWAYS);
 
-        outFlowSlider.valueProperty().addListener((ov, oldVal, newVal) ->
-            outFlowSlider.setValue(newVal.intValue()));
-
         pane.add(outFlowSlider, col++, row);
         GridPane.setMargin(outFlowSlider, ViewConstants.CONTROL_PADDING);
 
         //TextField and Label to show the current value and unit
         outFlowValue = new TextField("" + tank.getOutPipe().getValveThreshold());
+        outFlowValue.setTextFormatter(new TextFormatter<>(new IntegerStringConverter()));
         outFlowValue.setMaxWidth(ViewConstants.CONTROL_INPUT_WIDTH);
         pane.add(outFlowValue, col++, row);
         GridPane.setMargin(outFlowValue, ViewConstants.CONTROL_PADDING);

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/AbstractTankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/AbstractTankTab.java
@@ -121,7 +121,7 @@ public abstract class AbstractTankTab extends Tab implements Observer {
      * Updates the AbstractTankTab to show the values from the productionSite
      * @param tank The tank whose values are taken
      */
-    void update(AbstractTank tank) {
+    protected void update(AbstractTank tank) {
         outFlowSlider.setValue(tank.getOutPipe().getValveThreshold());
     }
 
@@ -129,7 +129,7 @@ public abstract class AbstractTankTab extends Tab implements Observer {
      * Sets the listener that is notified of changes to valve thresholds.
      * @param listener The Consumer that gets all changes to valve thresholds.
      */
-    void setValveListener(BiConsumer<Pipe, Byte> listener) {
+    protected void setValveListener(BiConsumer<Pipe, Byte> listener) {
         outFlowSlider.valueProperty().addListener((observable, oldValue, newValue) -> {
             skipUpdates = true;
             listener.accept(tank.getOutPipe(), newValue.byteValue());

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/MixTankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/MixTankTab.java
@@ -10,8 +10,10 @@ import javafx.beans.property.StringProperty;
 import javafx.scene.control.Label;
 import javafx.scene.control.Slider;
 import javafx.scene.control.TextField;
+import javafx.scene.control.TextFormatter;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
+import javafx.util.converter.IntegerStringConverter;
 
 import java.util.Observable;
 
@@ -61,14 +63,12 @@ public class MixTankTab extends AbstractTankTab {
         motorSlider.setPrefWidth(ViewConstants.CONTROL_SLIDER_WIDTH);
         GridPane.setHgrow(motorSlider, Priority.ALWAYS);
 
-        motorSlider.valueProperty().addListener((ov, oldVal, newVal) ->
-                motorSlider.setValue(newVal.intValue()));
-
         pane.add(motorSlider, col++, row);
         GridPane.setMargin(motorSlider, ViewConstants.CONTROL_PADDING);
 
         //TextField and Label to show the current value and unit
         motorValue = new TextField("" + tank.getMotor().getRPM());
+        motorValue.setTextFormatter(new TextFormatter<>(new IntegerStringConverter()));
         motorValue.setMaxWidth(ViewConstants.CONTROL_INPUT_WIDTH);
         pane.add(motorValue, col++, row);
         GridPane.setMargin(motorValue, ViewConstants.CONTROL_PADDING);

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/MixTankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/MixTankTab.java
@@ -126,7 +126,7 @@ public class MixTankTab extends AbstractTankTab {
      * Sets the listener that is notified of changes in motor speed.
      * @param listener The Consumer that gets all to the motorSpeed
      */
-    void setMotorListener(Consumer<Integer> listener) {
+    protected void setMotorListener(Consumer<Integer> listener) {
         motorSlider.valueProperty().addListener((observable, oldValue, newValue) -> {
             if (!skipUpdates) {
                 listener.accept(newValue.intValue());

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/SimulationControlWindow.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/SimulationControlWindow.java
@@ -78,7 +78,6 @@ public class SimulationControlWindow extends Stage implements SimulationControlI
         }
     }
 
-    @Override
     public void update() {
         for (TankSelector t : TankSelector.valuesWithoutMix()) {
             TankTab tab = (TankTab) tankTabs.get(t);

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/SimulationControlWindow.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/SimulationControlWindow.java
@@ -1,6 +1,5 @@
 package edu.kit.pse.osip.simulation.view.control;
 
-import edu.kit.pse.osip.core.SimulationConstants;
 import edu.kit.pse.osip.core.model.base.Pipe;
 import edu.kit.pse.osip.core.model.base.MixTank;
 import edu.kit.pse.osip.core.model.base.ProductionSite;
@@ -78,37 +77,13 @@ public class SimulationControlWindow extends Stage implements SimulationControlI
         }
     }
 
-    public void update() {
-        for (TankSelector t : TankSelector.valuesWithoutMix()) {
-            TankTab tab = (TankTab) tankTabs.get(t);
-            tab.update(productionSite.getUpperTank(t));
-        }
-
-        MixTankTab mixTab = (MixTankTab) tankTabs.get(TankSelector.MIX);
-        mixTab.update(productionSite.getMixTank());
-    }
-
     /**
      * Sets the listener that is notified of changes to valve thresholds.
      * @param listener The Consumer that gets all changes to valve thresholds.
      */
     public void setValveListener(BiConsumer<Pipe, Byte> listener) {
-        // Inflow listeners for all upper tanks
-        for (TankSelector t : TankSelector.valuesWithoutMix()) {
-            Pipe inPipe = productionSite.getUpperTank(t).getInPipe();
-            TankTab tab = (TankTab) tankTabs.get(t);
-            tab.getInFlowSlider().valueProperty().addListener((ov, oldVal, newVal) ->
-                listener.accept(inPipe, newVal.byteValue()));
-        }
-
-        // Outflow listeners for all tanks
-        Pipe mixInPipe = productionSite.getMixTank().getOutPipe();
-        tankTabs.get(TankSelector.MIX).getOutFlowSlider().valueProperty().addListener((ov, oldVal, newVal) ->
-                listener.accept(mixInPipe, newVal.byteValue()));
-        for (TankSelector t : TankSelector.valuesWithoutMix()) {
-            Pipe inPipe = productionSite.getUpperTank(t).getOutPipe();
-            tankTabs.get(t).getOutFlowSlider().valueProperty().addListener((ov, oldVal, newVal) ->
-                listener.accept(inPipe, newVal.byteValue()));
+        for (AbstractTankTab tab: tankTabs.values()) {
+            tab.setValveListener(listener);
         }
     }
 
@@ -119,8 +94,7 @@ public class SimulationControlWindow extends Stage implements SimulationControlI
     public void setTemperatureListener(BiConsumer<TankSelector, Float> listener) {
         for (TankSelector t : TankSelector.valuesWithoutMix()) {
             TankTab tab = (TankTab) tankTabs.get(t);
-            tab.getTemperatureSlider().valueProperty().addListener((ov, oldVal, newVal) ->
-                listener.accept(t, newVal.floatValue() + SimulationConstants.CELCIUS_OFFSET));
+            tab.setTemperatureListener(listener);
         }
     }
 
@@ -130,7 +104,6 @@ public class SimulationControlWindow extends Stage implements SimulationControlI
      */
     public void setMotorListener(Consumer<Integer> listener) {
         MixTankTab tab = (MixTankTab) tankTabs.get(TankSelector.MIX);
-        tab.getMotorSlider().valueProperty().addListener((ov, oldVal, newVal) ->
-            listener.accept(newVal.intValue()));
+        tab.setMotorListener(listener);
     }
 }

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/TankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/TankTab.java
@@ -13,8 +13,10 @@ import javafx.beans.property.StringProperty;
 import javafx.scene.control.Label;
 import javafx.scene.control.Slider;
 import javafx.scene.control.TextField;
+import javafx.scene.control.TextFormatter;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Priority;
+import javafx.util.converter.IntegerStringConverter;
 
 import java.util.Observable;
 
@@ -74,14 +76,12 @@ public class TankTab extends AbstractTankTab {
         inFlowSlider.setPrefWidth(ViewConstants.CONTROL_SLIDER_WIDTH);
         GridPane.setHgrow(inFlowSlider, Priority.ALWAYS);
 
-        inFlowSlider.valueProperty().addListener((ov, oldVal, newVal) ->
-                inFlowSlider.setValue(newVal.intValue()));
-
         pane.add(inFlowSlider, col++, row);
         GridPane.setMargin(inFlowSlider, ViewConstants.CONTROL_PADDING);
 
         //TextField and label to show the current value and unit
         inFlowValue = new TextField("" + tank.getOutPipe().getValveThreshold());
+        inFlowValue.setTextFormatter(new TextFormatter<>(new IntegerStringConverter()));
         inFlowValue.setMaxWidth(ViewConstants.CONTROL_INPUT_WIDTH);
         pane.add(inFlowValue, col++, row);
         GridPane.setMargin(inFlowValue, ViewConstants.CONTROL_PADDING);

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/TankTab.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/control/TankTab.java
@@ -185,7 +185,7 @@ public class TankTab extends AbstractTankTab {
     }
 
     @Override
-    void setValveListener(BiConsumer<Pipe, Byte> listener) {
+    protected void setValveListener(BiConsumer<Pipe, Byte> listener) {
         super.setValveListener(listener);
 
         inFlowSlider.valueProperty().addListener((observable, oldValue, newValue) -> {
@@ -199,7 +199,7 @@ public class TankTab extends AbstractTankTab {
      * Sets the listener that is notified of changes in the temperature.
      * @param listener The Consumer that gets all changes to Tank temperatures
      */
-    void setTemperatureListener(BiConsumer<TankSelector, Float> listener) {
+    protected void setTemperatureListener(BiConsumer<TankSelector, Float> listener) {
         temperatureSlider.valueProperty().addListener((observable, oldValue, newValue) -> {
             skipUpdates = true;
             listener.accept(selector, newValue.floatValue() + SimulationConstants.CELCIUS_OFFSET);

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMainWindow.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMainWindow.java
@@ -156,7 +156,7 @@ public class SimulationMainWindow implements SimulationViewInterface {
 
         mainPane.setStyle("-fx-font-size:" + ViewConstants.FONT_SIZE + "px;");
 
-        menu = new SimulationMenu(controlWindow);
+        menu = new SimulationMenu();
         mainPane.setTop(menu);
 
         canvas = setCanvas(primaryStage);

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMainWindow.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMainWindow.java
@@ -48,7 +48,7 @@ public class SimulationMainWindow implements SimulationViewInterface {
     private SimulationMenu menu;
     private Collection<Drawer> element;
     private Canvas canvas;
-    private EventHandler<ActionEvent> overflowClosedHandler;
+    private EventHandler<ActionEvent> resetHandler;
 
     /**
      * Creates a new SimulationMainWindow. It is assumed that there will only ever be two rows of tanks.
@@ -206,19 +206,14 @@ public class SimulationMainWindow implements SimulationViewInterface {
         EventHandler<ActionEvent> handler = new EventHandler<ActionEvent>() {
             @Override
             public void handle(ActionEvent actionEvent) {
-                if (overflowClosedHandler != null) {
-                    overflowClosedHandler.handle(actionEvent);
+                if (resetHandler != null) {
+                    resetHandler.handle(actionEvent);
                 }
             }
         };
 
         dialog.setResetButtonHandler(handler);
         dialog.show();
-    }
-
-    @Override
-    public void setOverflowClosedHandler(EventHandler<ActionEvent> handler) {
-        overflowClosedHandler = handler;
     }
 
     /**
@@ -283,6 +278,7 @@ public class SimulationMainWindow implements SimulationViewInterface {
 
     @Override
     public void setResetListener(EventHandler<ActionEvent> listener) {
+        resetHandler = listener;
         menu.setResetButtonHandler(listener);
     }
 

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMenu.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMenu.java
@@ -4,7 +4,6 @@ import edu.kit.pse.osip.core.utils.language.Translator;
 import java.io.File;
 import java.util.function.Consumer;
 
-import edu.kit.pse.osip.simulation.controller.SimulationControlInterface;
 import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.scene.control.Menu;
@@ -56,17 +55,13 @@ public class SimulationMenu extends MenuBar {
     private MenuItem menuItemStartScenario;
     private MenuItem menuItemStopScenario;
 
-    private SimulationControlInterface controlWindow;
 
     /**
      * Creates and initializes the menu for the simulation view.
-     * @param controlWindow The window containing the controls
      */
-    protected SimulationMenu(SimulationControlInterface controlWindow) {
+    protected SimulationMenu() {
         this.setStyle("-fx-font-size:" + ViewConstants.FONT_SIZE + "px;");
         Translator trans = Translator.getInstance();
-
-        this.controlWindow = controlWindow;
 
         menuButtonFile = new Menu(trans.getString("simulation.view.menu.file"));
         menuItemSettings = new MenuItem(trans.getString("simulation.view.menu.file.settings"));
@@ -166,6 +161,5 @@ public class SimulationMenu extends MenuBar {
     public void setScenarioFinished() {
         menuItemStartScenario.setDisable(false);
         menuItemStopScenario.setDisable(true);
-        controlWindow.setControlsDisabled(false);
     }
 }


### PR DESCRIPTION
Let the tank tabs register the listener and have a attribute which
tracks wether the model update is because of the slider, to ignore it.
This means that the model recieves updates all the time, except when the
updates are by itself. This is different than before, because before the
window had only recieved updates, if the control elements were disabled.

Additionally, improve some other small things.