### PR TITLE
Simulation view rotating fix

### DIFF
--- a/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Pipe.java
+++ b/src/osip-model/src/main/java/edu/kit/pse/osip/core/model/base/Pipe.java
@@ -1,8 +1,9 @@
 package edu.kit.pse.osip.core.model.base;
 
 import edu.kit.pse.osip.core.SimulationConstants;
-import java.util.Queue;
-import java.util.concurrent.LinkedBlockingQueue;
+
+import java.util.Deque;
+import java.util.concurrent.LinkedBlockingDeque;
 
 /**
  * A pipe, where you can insert and take out liquid. It is a queue, so if you put in liquid, you can take it out in
@@ -13,7 +14,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 public class Pipe extends java.util.Observable {
     private float crosssection;
     private int length;
-    private Queue<Liquid> queue = new LinkedBlockingQueue<>();
+    private Deque<Liquid> queue = new LinkedBlockingDeque<>();
     private byte threshold = 100; /* in percent */
     private byte defaultThreshold;
 
@@ -46,14 +47,14 @@ public class Pipe extends java.util.Observable {
             throw new OverfullLiquidContainerException("To much liquid inserted into the pipe",
                     getMaxInput(), liquid.getAmount());
         }
-        queue.add(liquid);
+        queue.addLast(liquid);
         setChanged();
         if (queue.size() <= length) {
             notifyObservers();
             /* Pipe not filled */
             return new Liquid(0, SimulationConstants.MIN_TEMPERATURE, new Color(0));
         } else {
-            Liquid ret = queue.remove();
+            Liquid ret = queue.removeFirst();
             notifyObservers();
             return ret;
         }
@@ -106,5 +107,18 @@ public class Pipe extends java.util.Observable {
         queue.clear();
         setChanged();
         notifyObservers();
+    }
+
+    /**
+     * Checks whether there is currently any amount of liquid at the beginning and thus
+     * entering the pipe.
+     * @return True if the last Liquid put in has an amount > 0, false if the amount is 0 or there
+     *      is not a Liquid object.
+     */
+    public boolean isLiquidEntering() {
+        if (queue.peekLast() == null) {
+            return false;
+        }
+        return queue.peekLast().getAmount() != 0;
     }
 }

--- a/src/osip-simulation-controller/src/main/java/edu/kit/pse/osip/simulation/controller/PhysicsSimulator.java
+++ b/src/osip-simulation-controller/src/main/java/edu/kit/pse/osip/simulation/controller/PhysicsSimulator.java
@@ -37,7 +37,8 @@ public class PhysicsSimulator {
         }
 
         mixTank.putIn(mixInput);
-        mixTank.takeOut(mixTank.getOutPipe().getMaxInput());
+        Pipe mixOutPipe = mixTank.getOutPipe();
+        mixOutPipe.putIn(mixTank.takeOut(mixTank.getOutPipe().getMaxInput()));
     }
 
     /**

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/AbstractTankDrawer.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/AbstractTankDrawer.java
@@ -138,9 +138,9 @@ public abstract class AbstractTankDrawer extends ObjectDrawer {
     /**
      * Used by draw(). Adds some detail to the tank depending on tank type.
      * @param context The GraphicsContext on which the sensors are drawn
-     * @param time The time passed
+     * @param timeDiff The time passed in minutes since the last call of drawSensors
      */
-    public abstract void drawSensors(GraphicsContext context, double time);
+    public abstract void drawSensors(GraphicsContext context, double timeDiff);
 
     /**
      * Gets the point where pipes can attach to the bottom of the tank. This point lies in the

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/Drawer.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/Drawer.java
@@ -13,7 +13,7 @@ public interface Drawer {
     /**
      * The Drawer draws itself onto the GraphicsContext at its position.
      * @param context The context that the object draws itself onto
-     * @param time The current time in nanoseconds as supplied by ApplicationTimer
+     * @param timeDiff The difference in time in minutes since the last call of draw.
      */
-    void draw(GraphicsContext context, double time);
+    void draw(GraphicsContext context, double timeDiff);
 }

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/FillSensorDrawer.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/FillSensorDrawer.java
@@ -27,13 +27,8 @@ public class FillSensorDrawer extends ObjectDrawer {
         this.cols = cols;
     }
 
-    /**
-     * The Drawer draws itself onto the GraphicsContext at its position.
-     * @param context The context that the object draws itself onto
-     * @param time
-     */
     @Override
-    public final void draw(GraphicsContext context, double time) {
+    public final void draw(GraphicsContext context, double timeDiff) {
         context.setFill(Color.BLACK);
         context.setStroke(Color.BLACK);
         context.setLineWidth(2);

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/MixTankDrawer.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/MixTankDrawer.java
@@ -53,14 +53,12 @@ public class MixTankDrawer extends AbstractTankDrawer {
 
     /**
      * Add Temperature- and Fillsensors as well as a motor visualization to the tank.
-     * @param context The GraphicsContext on which the sensors are drawn.
-     * @param time
      */
     @Override
-    public final void drawSensors(GraphicsContext context, double time) {
-        topSensor.draw(context, time);
-        botSensor.draw(context, time);
-        tempSensor.draw(context, time);
-        motor.draw(context, time);
+    public final void drawSensors(GraphicsContext context, double timeDiff) {
+        topSensor.draw(context, timeDiff);
+        botSensor.draw(context, timeDiff);
+        tempSensor.draw(context, timeDiff);
+        motor.draw(context, timeDiff);
     }
 }

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/MotorDrawer.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/MotorDrawer.java
@@ -31,16 +31,11 @@ public class MotorDrawer extends RotatingControlDrawer {
         relRadius = ViewConstants.MOTOR_RADIUS / cols;
     }
 
-    /**
-     * The Drawer draws itself onto the GraphicsContext at its position.
-     * @param context The context that the object draws itself onto
-     * @param time
-     */
     @Override
-    public final void draw(GraphicsContext context, double time) {
+    public final void draw(GraphicsContext context, double timeDiff) {
         setSpeed(motor.getRPM());
 
-        updateDegrees(time, ViewConstants.MOTOR_SPEED_FACTOR);
+        updateDegrees(timeDiff, ViewConstants.MOTOR_SPEED_FACTOR);
 
         Canvas canvas = context.getCanvas();
         double totalWidth = canvas.getWidth();

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/MotorDrawer.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/MotorDrawer.java
@@ -40,8 +40,7 @@ public class MotorDrawer extends RotatingControlDrawer {
     public final void draw(GraphicsContext context, double time) {
         setSpeed(motor.getRPM());
 
-        // Convert the minutes to degrees to be turned in total
-        double degrees = time * (getSpeed() * ViewConstants.MOTOR_SPEED_FACTOR) * 360;
+        updateDegrees(time, ViewConstants.MOTOR_SPEED_FACTOR);
 
         Canvas canvas = context.getCanvas();
         double totalWidth = canvas.getWidth();
@@ -69,14 +68,14 @@ public class MotorDrawer extends RotatingControlDrawer {
         //This leads to a white outline and visibility in all cases.
         context.setStroke(Color.WHITE);
         context.setLineWidth(ViewConstants.MOTOR_LINE_WIDTH + 2);
-        context.strokeLine(rotateX(point1xPos, centerX, point1yPos, centerY, degrees),
-                rotateY(point1xPos, centerX, point1yPos, centerY, degrees),
-                rotateX(point3xPos, centerX, point3yPos, centerY, degrees),
-                rotateY(point3xPos, centerX, point3yPos, centerY, degrees));
-        context.strokeLine(rotateX(point2xPos, centerX, point2yPos, centerY, degrees),
-                rotateY(point2xPos, centerX, point2yPos, centerY, degrees),
-                rotateX(point4xPos, centerX, point4yPos, centerY, degrees),
-                rotateY(point4xPos, centerX, point4yPos, centerY, degrees));
+        context.strokeLine(rotateX(point1xPos, centerX, point1yPos, centerY, getDegrees()),
+                rotateY(point1xPos, centerX, point1yPos, centerY, getDegrees()),
+                rotateX(point3xPos, centerX, point3yPos, centerY, getDegrees()),
+                rotateY(point3xPos, centerX, point3yPos, centerY, getDegrees()));
+        context.strokeLine(rotateX(point2xPos, centerX, point2yPos, centerY, getDegrees()),
+                rotateY(point2xPos, centerX, point2yPos, centerY, getDegrees()),
+                rotateX(point4xPos, centerX, point4yPos, centerY, getDegrees()),
+                rotateY(point4xPos, centerX, point4yPos, centerY, getDegrees()));
 
         context.strokeOval(point1xPos, point2yPos, relRadius * 2 * totalWidth, relRadius * 2 * totalWidth);
 
@@ -84,14 +83,14 @@ public class MotorDrawer extends RotatingControlDrawer {
         context.setLineWidth(ViewConstants.MOTOR_LINE_WIDTH);
 
         // Draw the two rotated lines.
-        context.strokeLine(rotateX(point1xPos, centerX, point1yPos, centerY, degrees),
-                rotateY(point1xPos, centerX, point1yPos, centerY, degrees),
-                rotateX(point3xPos, centerX, point3yPos, centerY, degrees),
-                rotateY(point3xPos, centerX, point3yPos, centerY, degrees));
-        context.strokeLine(rotateX(point2xPos, centerX, point2yPos, centerY, degrees),
-                rotateY(point2xPos, centerX, point2yPos, centerY, degrees),
-                rotateX(point4xPos, centerX, point4yPos, centerY, degrees),
-                rotateY(point4xPos, centerX, point4yPos, centerY, degrees));
+        context.strokeLine(rotateX(point1xPos, centerX, point1yPos, centerY, getDegrees()),
+                rotateY(point1xPos, centerX, point1yPos, centerY, getDegrees()),
+                rotateX(point3xPos, centerX, point3yPos, centerY, getDegrees()),
+                rotateY(point3xPos, centerX, point3yPos, centerY, getDegrees()));
+        context.strokeLine(rotateX(point2xPos, centerX, point2yPos, centerY, getDegrees()),
+                rotateY(point2xPos, centerX, point2yPos, centerY, getDegrees()),
+                rotateX(point4xPos, centerX, point4yPos, centerY, getDegrees()),
+                rotateY(point4xPos, centerX, point4yPos, centerY, getDegrees()));
 
         // There would be not much sense in rotating a circle.
         context.strokeOval(point1xPos, point2yPos, relRadius * 2 * totalWidth, relRadius * 2 * totalWidth);

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/ObjectDrawer.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/ObjectDrawer.java
@@ -1,7 +1,5 @@
 package edu.kit.pse.osip.simulation.view.main;
 
-import javafx.scene.canvas.GraphicsContext;
-
 /**
  * The parent class for all non-moving objects of the simulation. The only data it needs
  * is a position where to draw itself.
@@ -29,11 +27,4 @@ public abstract class ObjectDrawer implements Drawer {
     public final Point2D getPosition() {
         return position;
     }
-
-    /**
-     * The Drawer draws itself onto the GraphicsContext at its position.
-     * @param context The context that the object draws itself onto
-     * @param time The current time in nanoseconds
-     */
-    public abstract void draw(GraphicsContext context, double time);
 }

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/PipeDrawer.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/PipeDrawer.java
@@ -49,13 +49,8 @@ public class PipeDrawer implements Drawer {
         valve = new ValveDrawer(new Point2D(valveX, valveY), pipe, rows);
     }
 
-    /**
-     * The Drawer draws itself onto the GraphicsContext at its position.
-     * @param context The context that the object draws itself onto
-     * @param time
-     */
     @Override
-    public final void draw(GraphicsContext context, double time) {
+    public final void draw(GraphicsContext context, double timeDiff) {
         context.setStroke(Color.BLACK);
         Canvas canvas = context.getCanvas();
         double totalWidth = canvas.getWidth();
@@ -85,6 +80,6 @@ public class PipeDrawer implements Drawer {
             context.strokeLine(x1, y1, x2, y2);
         }
 
-        valve.draw(context, time);
+        valve.draw(context, timeDiff);
     }
 }

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/RotatingControlDrawer.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/RotatingControlDrawer.java
@@ -11,6 +11,7 @@ package edu.kit.pse.osip.simulation.view.main;
 public abstract class RotatingControlDrawer extends ObjectDrawer {
 
     private int speed;
+    private double degrees;
 
     /**
      * Sets the position by using super(pos) and the rotation speed.
@@ -20,14 +21,26 @@ public abstract class RotatingControlDrawer extends ObjectDrawer {
     public RotatingControlDrawer(Point2D pos, int speed) {
         super(pos);
         this.speed = speed;
+        degrees = 0;
     }
 
     /**
-     * Get the rotation speed of the RotatingControlDrawer
-     * @return The current value of speed
+     * Gets the value of degrees
+     * @return The value of degrees
      */
-    public int getSpeed() {
-        return speed;
+    public double getDegrees() {
+        return degrees;
+    }
+
+    /**
+     * Updates the total amount of degrees turned accoring to the time passed and norms it to
+     * the interval [0, 360)
+     * @param timeDiff The time passed since the last update
+     * @param speedFactor Fraction of the speed that is actually to be displayed for aesthetic reasons
+     */
+    public void updateDegrees(double timeDiff, double speedFactor) {
+        degrees = degrees + (timeDiff * (speed * speedFactor) * 360);
+        degrees = degrees % 360;
     }
 
     /**

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMainWindow.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMainWindow.java
@@ -185,11 +185,16 @@ public class SimulationMainWindow implements SimulationViewInterface {
         setResizeListeners(primaryStage);
 
         new AnimationTimer() {
+            private long oldTime = System.nanoTime();
+
             public void handle(long currentTimeNs) {
+                long timeDiffNs = currentTimeNs - oldTime;
+                oldTime = currentTimeNs;
+
                 context.clearRect(0, 0, canvas.getWidth(), canvas.getHeight());
                 for (Drawer d : element) {
-                    double currentTime = ((double) currentTimeNs) / (1000000000.0 * 60);
-                    d.draw(context, currentTime);
+                    double timeDiff = ((double) timeDiffNs) / (1000000000.0 * 60);
+                    d.draw(context, timeDiff);
                 }
             }
         }.start();

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/TankDrawer.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/TankDrawer.java
@@ -48,13 +48,11 @@ public class TankDrawer extends AbstractTankDrawer {
 
     /**
      * Add temperature- and fillsensor visualizations to the tank.
-     * @param context The GraphicsContext belonging to the canvas on which everything is drawn
-     * @param time The current time in nanoseconds
      */
     @Override
-    public final void drawSensors(GraphicsContext context, double time) {
-        topSensor.draw(context, time);
-        botSensor.draw(context, time);
-        tempSensor.draw(context, time);
+    public final void drawSensors(GraphicsContext context, double timeDiff) {
+        topSensor.draw(context, timeDiff);
+        botSensor.draw(context, timeDiff);
+        tempSensor.draw(context, timeDiff);
     }
 }

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/TemperatureSensorDrawer.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/TemperatureSensorDrawer.java
@@ -32,13 +32,8 @@ public class TemperatureSensorDrawer extends ObjectDrawer {
         this.cols = cols;
     }
 
-    /**
-     * The Drawer draws itself onto the GraphicsContext at its getPosition().
-     * @param context The context that the object draws itself onto
-     * @param currentTime
-     */
     @Override
-    public final void draw(GraphicsContext context, double currentTime) {
+    public final void draw(GraphicsContext context, double timeDiff) {
         Canvas canvas = context.getCanvas();
 
         double temp = (tank.getLiquid().getTemperature() - SimulationConstants.MIN_TEMPERATURE)

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/ValveDrawer.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/ValveDrawer.java
@@ -34,16 +34,13 @@ public class ValveDrawer extends RotatingControlDrawer {
         relValveHeight = ViewConstants.VALVE_HEIGHT / rows;
     }
 
-    /**
-     * The Drawer draws itself onto the GraphicsContext at its position.
-     * @param context The context that the object draws itself onto
-     * @param time
-     */
     @Override
-    public final void draw(GraphicsContext context, double time) {
+    public final void draw(GraphicsContext context, double timeDiff) {
         setSpeed(pipe.getValveThreshold());
 
-        updateDegrees(time, 0.5);
+        if (pipe.isLiquidEntering()) {
+            updateDegrees(timeDiff, 0.5);
+        }
 
         Canvas canvas = context.getCanvas();
         double totalWidth = canvas.getWidth();

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/ValveDrawer.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/ValveDrawer.java
@@ -42,8 +42,8 @@ public class ValveDrawer extends RotatingControlDrawer {
     @Override
     public final void draw(GraphicsContext context, double time) {
         setSpeed(pipe.getValveThreshold());
-        // Convert the minutes to degrees to be turned in total
-        double degrees = time * getSpeed() / 2 * 360;
+
+        updateDegrees(time, 0.5);
 
         Canvas canvas = context.getCanvas();
         double totalWidth = canvas.getWidth();
@@ -77,14 +77,14 @@ public class ValveDrawer extends RotatingControlDrawer {
         context.fillRect(valveTopLeftX, valveTopLeftY, valveWidth, valveHeight);
         context.strokeRect(valveTopLeftX, valveTopLeftY, valveWidth, valveHeight);
 
-        context.strokeLine(rotateX(point1xPos, centerX, point1yPos, centerY, degrees),
-                rotateY(point1xPos, centerX, point1yPos, centerY, degrees),
-                rotateX(point3xPos, centerX, point3yPos, centerY, degrees),
-                rotateY(point3xPos, centerX, point3yPos, centerY, degrees));
-        context.strokeLine(rotateX(point2xPos, centerX, point2yPos, centerY, degrees),
-                rotateY(point2xPos, centerX, point2yPos, centerY, degrees),
-                rotateX(point4xPos, centerX, point4yPos, centerY, degrees),
-                rotateY(point4xPos, centerX, point4yPos, centerY, degrees));
+        context.strokeLine(rotateX(point1xPos, centerX, point1yPos, centerY, getDegrees()),
+                rotateY(point1xPos, centerX, point1yPos, centerY, getDegrees()),
+                rotateX(point3xPos, centerX, point3yPos, centerY, getDegrees()),
+                rotateY(point3xPos, centerX, point3yPos, centerY, getDegrees()));
+        context.strokeLine(rotateX(point2xPos, centerX, point2yPos, centerY, getDegrees()),
+                rotateY(point2xPos, centerX, point2yPos, centerY, getDegrees()),
+                rotateX(point4xPos, centerX, point4yPos, centerY, getDegrees()),
+                rotateY(point4xPos, centerX, point4yPos, centerY, getDegrees()));
         context.strokeOval(point1xPos, point2yPos,
                 radius * 2 * totalHeight - 2 * ViewConstants.VALVE_CIRCLE_DIST * valveWidth,
                 radius * 2 * totalHeight - 2 * ViewConstants.VALVE_CIRCLE_DIST * valveWidth);


### PR DESCRIPTION
Es gibt keine Spruenge mehr in der Animation, wenn sich die Geschwindigkeit drehender Elemente aendert.
Die Kreise in ValveDrawer drehen sich nur noch, wenn aktuell immer noch Liquid einer Menge > 0 in die Pipe eingegeben wird.
Dazu wurde die Simulation geaendert, damit tatsaechlich Liquid in die Pipe gegeben wird, die den MixTank verlaesst, da sich der ValveDrawer sonst nicht drehen wuerde.