### PR TITLE
Check checkstyle rules for all java files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,7 @@ script:
 - test `find . -not -type d -exec file "{}" ";" | grep CRLF | wc -l` -eq 0
 - cd src
 - mvn -U -B test
-- cd ..
-- git fetch origin master
-- git diff --name-only FETCH_HEAD | { grep "\.java" || true; }
-- git diff --name-only FETCH_HEAD | grep "\.java" | xargs -r java -jar tools/checkstyle-7.4-all.jar -c src/checkstyle.xml
-- git diff --name-only FETCH_HEAD | grep "\.java" | xargs -r java -jar tools/checkstyle-7.4-all.jar -c src/checkstyle.xml | wc -l | xargs test 2 -ge
-- cd docs
+- cd ../docs
 - export max_print_line=200
 - pdflatex -interaction=batchmode Pflichtenheft &> /dev/null
 - cat Pflichtenheft.log | grep -C 15 -i ERROR

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -77,4 +77,30 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-checkstyle-plugin</artifactId>
+				<version>2.17</version>
+				<executions>
+					<execution>
+						<id>validate</id>
+						<phase>validate</phase>
+						<configuration>
+							<configLocation>checkstyle.xml</configLocation>
+							<violationSeverity>warning</violationSeverity>
+							<consoleOutput>true</consoleOutput>
+							<failsOnError>true</failsOnError>
+							<linkXRef>false</linkXRef>
+						</configuration>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>


### PR DESCRIPTION
There is no need for this hack to exclude autogenerated files anymore.