### PR TITLE
[monitor/view] Disable progression tabs and clear data when disabled

### DIFF
--- a/src/osip-monitoring-view/src/main/java/edu/kit/pse/osip/monitoring/view/dashboard/ProgressVisualization.java
+++ b/src/osip-monitoring-view/src/main/java/edu/kit/pse/osip/monitoring/view/dashboard/ProgressVisualization.java
@@ -109,7 +109,12 @@ class ProgressVisualization {
      * @param progressEnabled true if the progression should be enabled and false otherwise.
      */
     protected void setProgressEnabled(boolean progressEnabled) {
+        if (progressEnabled && !isEnabled) {
+            progressSeries.getData().clear();
+            x = 0;
+        }
         isEnabled = progressEnabled;
+        progressChart.setDisable(!progressEnabled);
     }
     
     /**


### PR DESCRIPTION
Otherwise the progressions just stop, but it isn't visible that they are
disabled.