### PR TITLE
[view] Changed alert dialogs to modal windows

### DIFF
--- a/src/osip-monitoring-view/src/main/java/edu/kit/pse/osip/monitoring/view/settings/SettingsMainWindow.java
+++ b/src/osip-monitoring-view/src/main/java/edu/kit/pse/osip/monitoring/view/settings/SettingsMainWindow.java
@@ -15,6 +15,7 @@ import javafx.scene.control.TabPane.TabClosingPolicy;
 import javafx.scene.image.Image;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
+import javafx.stage.Modality;
 import javafx.stage.Stage;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
@@ -152,6 +153,8 @@ class SettingsMainWindow {
         alert.setContentText(translator.getString("monitoring.settings.closewarning.text"));
         Stage stage = (Stage) alert.getDialogPane().getScene().getWindow();
         stage.getIcons().add(new Image("/icon.png"));
+        alert.initModality(Modality.APPLICATION_MODAL);
+        alert.initOwner(window);
         alert.show();
     }
     

--- a/src/osip-monitoring-view/src/main/java/edu/kit/pse/osip/monitoring/view/settings/SettingsViewFacade.java
+++ b/src/osip-monitoring-view/src/main/java/edu/kit/pse/osip/monitoring/view/settings/SettingsViewFacade.java
@@ -8,6 +8,7 @@ import javafx.event.ActionEvent;
 import javafx.event.EventHandler;
 import javafx.scene.control.Alert;
 import javafx.scene.image.Image;
+import javafx.stage.Modality;
 import javafx.stage.Stage;
 
 /**
@@ -39,6 +40,8 @@ public class SettingsViewFacade implements SettingsViewInterface {
         disconnectAlert.setContentText(t.getString("monitoring.settings.disconnectalert.text"));
         Stage stage = (Stage) disconnectAlert.getDialogPane().getScene().getWindow();
         stage.getIcons().add(new Image("/icon.png"));
+        disconnectAlert.initModality(Modality.APPLICATION_MODAL);
+        disconnectAlert.initOwner(currentSettingsWindow.getStage());
 
         cannotConnectAlert = new Alert(Alert.AlertType.ERROR);
         cannotConnectAlert.setTitle(t.getString("monitoring.settings.cannotconnectalert.title"));
@@ -46,6 +49,8 @@ public class SettingsViewFacade implements SettingsViewInterface {
         cannotConnectAlert.setContentText(t.getString("monitoring.settings.cannotconnectalert.text"));
         stage = (Stage) cannotConnectAlert.getDialogPane().getScene().getWindow();
         stage.getIcons().add(new Image("/icon.png"));
+        cannotConnectAlert.initModality(Modality.APPLICATION_MODAL);
+        cannotConnectAlert.initOwner(currentSettingsWindow.getStage());
     }
     
     @Override

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMainWindow.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMainWindow.java
@@ -27,6 +27,7 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Font;
+import javafx.stage.Modality;
 import javafx.stage.Stage;
 import java.util.Collection;
 import java.util.ArrayList;
@@ -225,6 +226,8 @@ public class SimulationMainWindow implements SimulationViewInterface {
      */
     public void showOverflow(AbstractTank tank) {
         OverflowDialog dialog = new OverflowDialog(tank);
+        dialog.initModality(Modality.APPLICATION_MODAL);
+        dialog.initOwner(stage);
         EventHandler<ActionEvent> handler = actionEvent -> {
             if (resetHandler != null) {
                 resetHandler.handle(actionEvent);
@@ -262,6 +265,8 @@ public class SimulationMainWindow implements SimulationViewInterface {
         errorDialog.setHeaderText(t.getString("simulation.view.scenario.error.header"));
         errorDialog.setContentText(error);
         errorDialog.getDialogPane().setMinHeight(Region.USE_PREF_SIZE);
+        errorDialog.initModality(Modality.APPLICATION_MODAL);
+        errorDialog.initOwner(stage);
         Stage stage = (Stage) errorDialog.getDialogPane().getScene().getWindow();
         stage.getIcons().add(new Image("/icon.png"));
         errorDialog.show();
@@ -289,6 +294,8 @@ public class SimulationMainWindow implements SimulationViewInterface {
             errorDialog.setHeaderText(t.getString("simulation.view.opcua.error.header"));
             errorDialog.setContentText(message);
             errorDialog.getDialogPane().setMinHeight(Region.USE_PREF_SIZE);
+            errorDialog.initModality(Modality.APPLICATION_MODAL);
+            errorDialog.initOwner(stage);
             Stage stage = (Stage) errorDialog.getDialogPane().getScene().getWindow();
             stage.getIcons().add(new Image("/icon.png"));
             errorDialog.show();


### PR DESCRIPTION
This way, the underlaying window can not be selected without showing the
alert dialog. This helps to prevent the situation where you can not interact
with a window because the alert dialog is shown in background.