### PR TITLE
[simulation/controller] Don't use random sleep value in integration test

### DIFF
--- a/src/osip-integration-test/src/test/java/edu/kit/pse/osip/monitoring/SimulationControllerTest.java
+++ b/src/osip-integration-test/src/test/java/edu/kit/pse/osip/monitoring/SimulationControllerTest.java
@@ -40,9 +40,8 @@ public class SimulationControllerTest extends ApplicationTest {
      * @throws UAClientException    If connecting to the OPC UA servers fails.
      * @throws InterruptedException If sleep fails
      */
-    @Test(timeout = 30000)
+    @Test(timeout = 60000)
     public void testLaunch() throws UAClientException, InterruptedException {
-        Thread.sleep(5000);
         File settingsLocation = new File(System.getProperty("user.home") + File.separator + ".osip");
         settingsLocation.mkdirs();
         ServerSettingsWrapper settings = new ServerSettingsWrapper(new File(settingsLocation, "simulation.conf"));
@@ -52,8 +51,18 @@ public class SimulationControllerTest extends ApplicationTest {
         TankClient client = new TankClient(new RemoteMachine("127.0.0.1",
             settings.getServerPort(TankSelector.valuesWithoutMix()[0], OSIPConstants.DEFAULT_PORT_MIX + 1)));
 
-        mixClient.connectClient();
-        client.connectClient();
+        while (true) {
+            try {
+                mixClient.connectClient();
+                client.connectClient();
+                break;
+            } catch (UAClientException ex) {
+                System.err.println("Exception when connecting to OPC UA server."
+                    + " Waiting for some time before reconnecting");
+                ex.printStackTrace();
+                Thread.sleep(1000);
+            }
+        }
         mixClient.disconnectClient();
         client.disconnectClient();
     }


### PR DESCRIPTION
Instead try to reconnect and wait for a second if it fails. Therefore it
doesn't matter how long the servers need to initialize themself as long
as it's less than one minute.