### PR TITLE
[simulation.view] Fix view for more than 3 upper tanks

### DIFF
--- a/docs/Qualitaetssicherung.tex
+++ b/docs/Qualitaetssicherung.tex
@@ -65,6 +65,8 @@ ungewöhnliche Eingaben ausgelöst werden konnten. Die wichtigsten Änderungen s
  \item Verbessern der mitgelieferten Szenarien.
  \item Besseres Visualisieren von ausgeschalteten Verläufen.
  \item Vereinfachen des Codes an einigen Stellen.
+ \item Anpassen des Algorithmus, der die Position der Rohre zwischen den Tanks bestimmt. Für beliebig viele obere Tanks werden die Rohre nun so gezeichnet,
+	dass es nicht zu Überschneidungen kommt.
 \end{itemize}
 
 \section{Unittests}

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/PipeDrawer.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/PipeDrawer.java
@@ -15,7 +15,6 @@ import javafx.scene.paint.Color;
 public class PipeDrawer implements Drawer {
     private Point2D[] wayPoints;
     private ValveDrawer valve;
-    private double relPipeWidth;
 
     /**
      * Creates a new pipe along the wayPoints 1 to n.
@@ -39,7 +38,6 @@ public class PipeDrawer implements Drawer {
         }
 
         this.wayPoints = wayPoints;
-        relPipeWidth = ViewConstants.PIPE_WIDTH / rows;
 
         //Set the valve p*100 % of the way along the way connecting the first two wayPoints
         double p = 0.15;
@@ -58,7 +56,7 @@ public class PipeDrawer implements Drawer {
 
         // length - 1 as we always draw from the current to the next point.
         for (int i = 0; i < wayPoints.length - 1; i++) {
-            double rectWidth = relPipeWidth * totalWidth;
+            double rectWidth = ViewConstants.PIPE_WIDTH * totalWidth;
             context.setLineWidth(rectWidth);
 
             double x1 = wayPoints[i].getX() * totalWidth;

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMainWindow.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/SimulationMainWindow.java
@@ -109,35 +109,35 @@ public class SimulationMainWindow implements SimulationViewInterface {
         // of the element list, as they need to draw over other Drawers
         List<Drawer> pipes = new ArrayList<>();
 
-        int tankCount = TankSelector.getUpperTankCount();
-
         // get all the tanks from the productionSite
-        MixTank mix = productionSite.getMixTank();
-        double mixXPos = ((double) (tankCount - 1)) / (tankCount * 2);
+        double mixXPos = ((double) (TankSelector.getUpperTankCount() - 1)) / (TankSelector.getUpperTankCount() * 2);
         //Assuming there are only ever two rows of tanks
         double mixYPos = 0.5;
         Point2D mixPos = new Point2D(mixXPos, mixYPos);
-        MixTankDrawer mtDrawer = new MixTankDrawer(mixPos, mix, ROWS, tankCount);
+        MixTankDrawer mtDrawer = new MixTankDrawer(mixPos, productionSite.getMixTank(),
+                ROWS, TankSelector.getUpperTankCount());
         element.add(mtDrawer);
 
         //Add a pipe leading out of the mixTank.
-        pipes.add(createMixTankOutPipe(mix, mtDrawer));
+        pipes.add(createMixTankOutPipe(productionSite.getMixTank(), mtDrawer));
 
         TankSelector[] topTanks = TankSelector.valuesWithoutMix();
 
-        for (int i = 0; i < tankCount; i++) {
+        for (int i = 0; i < TankSelector.getUpperTankCount(); i++) {
             //Add a new TankDrawer
-            double xPos = i * (1.0 / tankCount);
+            double xPos = i * (1.0 / TankSelector.getUpperTankCount());
             Point2D position = new Point2D(xPos, 0.0);
             Tank tank = productionSite.getUpperTank(topTanks[i]);
-            TankDrawer tankDrawer = new TankDrawer(position, tank, ROWS, tankCount);
+            TankDrawer tankDrawer = new TankDrawer(position, tank, ROWS, TankSelector.getUpperTankCount());
             element.add(tankDrawer);
 
             //Create a pipe leading from the top to the tank
             pipes.add(createTopPipe(tank, tankDrawer));
 
             //Create a pipe leading from the tank to the mixTank
-            pipes.add(createMixPipe(tank, tankDrawer, mtDrawer, i + 1));
+            double middleI = (double) (TankSelector.getUpperTankCount() - 1) / 2;
+            int offset = (int) Math.ceil(Math.abs((middleI - i)));
+            pipes.add(createMixPipe(tank, tankDrawer, mtDrawer, i + 1, offset));
         }
 
         element.addAll(pipes);
@@ -156,11 +156,15 @@ public class SimulationMainWindow implements SimulationViewInterface {
     /**
      * Creates a PipeDrawer leading from the TankDrawer to the MixTankDrawer.
      */
-    private PipeDrawer createMixPipe(Tank tank, TankDrawer tankDrawer, MixTankDrawer mixTankDrawer, int pipeNum) {
+    private PipeDrawer createMixPipe(Tank tank, TankDrawer tankDrawer, MixTankDrawer mixTankDrawer,
+                                     int pipeNum, int offset) {
         Point2D botStart = tankDrawer.getPipeStartPoint();
         Point2D botEnd = mixTankDrawer.getPipeEndPoint(pipeNum, TankSelector.getUpperTankCount());
-        Point2D botMid1 = new Point2D(botStart.getX(), 0.5);
-        Point2D botMid2 = new Point2D(botEnd.getX(), 0.5);
+        double midY = botStart.getY()
+                + (ViewConstants.OUTBOX_PERCENT - ViewConstants.INBOX_HEIGHT - ViewConstants.OVAL_PERCENT)
+                / ROWS / 2 + 2.5 * offset * ViewConstants.PIPE_WIDTH;
+        Point2D botMid1 = new Point2D(botStart.getX(), midY);
+        Point2D botMid2 = new Point2D(botEnd.getX(), midY);
         Point2D[] botWayPoints = {botStart, botMid1, botMid2, botEnd};
         return new PipeDrawer(botWayPoints, tank.getOutPipe(),  ROWS);
     }

--- a/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/ViewConstants.java
+++ b/src/osip-simulation-view/src/main/java/edu/kit/pse/osip/simulation/view/main/ViewConstants.java
@@ -1,6 +1,7 @@
 package edu.kit.pse.osip.simulation.view.main;
 
 import edu.kit.pse.osip.core.SimulationConstants;
+import edu.kit.pse.osip.core.model.base.TankSelector;
 import javafx.geometry.Insets;
 import javafx.stage.Screen;
 
@@ -110,7 +111,10 @@ public final class ViewConstants {
     /**
      * The width of a pipe relative to the width of a tank compartment.
      */
-    protected static final double PIPE_WIDTH = 0.017;
+    protected static final double PIPE_WIDTH = ((((1 - OUTBOX_PERCENT) / 2)
+            < (INBOX_WIDTH / TankSelector.getUpperTankCount()))
+            ? (1 - OUTBOX_PERCENT) : INBOX_WIDTH / TankSelector.getUpperTankCount())
+            / 3 / TankSelector.getUpperTankCount();
 
     /**
      * The width of a valve relative to the width of a tank compartment.


### PR DESCRIPTION
Die Formel des Todes fuer PIPE_WIDTH. Kommt daher, dass die Breite der Rohre davon abhaengt, ob der Abstand der beiden Tankreihen oder die Breite eines Tanks der limitierende Faktor ist. Und weil das ganze reinkompiliert wird gibt es den maximalen ternaeren Operator!

Dafuer sollten die Rohre jetzt mit beliebig vielen Tanks recht vernuenftig aussehen.